### PR TITLE
Fix: add flag builder.gasLimit with 100M arg

### DIFF
--- a/reth/etc/docker-compose.yml
+++ b/reth/etc/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       --nat=publicip
       --authrpc.port=8551 --authrpc.jwtsecret=/root/jwt/jwtsecret --authrpc.addr=0.0.0.0
       --log.file.directory /root/logs
+      --builder.gaslimit 100000000
 
 volumes:
   execution_data:


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add flag builder.gasLimit with 100M arg
<!--- Describe your changes in detail -->

## Motivation and Context
This aims to fix an issue where the block gas limit is overridden to 30M when running reth in dev mode
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
We will test on the VM
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)