### PR TITLE
feat: add reth profile to docker compose

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -12,29 +12,43 @@
 4. Start the application:  
    Run the following command to start the services using Docker Compose:  
    ```bash
-   docker compose --env-file ./reth/env.tmp up -d
+   docker compose --env-file ./reth/env.tmp --profile reth up -d
    ```
    To stop use
    ```bash
-   docker compose down
+   docker compose --profile reth down
    ```
    To stop and delete volumes use
    ```bash
-   docker compose down -v
+   docker compose --profile reth down -v
    ```
 
 5. If you want to run your node with Blockscout
    ```
-   docker compose --env-file ./reth/env.tmp --profile blockscout up -d
+   docker compose --env-file ./reth/env.tmp --profile reth --profile blockscout up -d
    ```
    **Note**:
    If you are not accessing blockscout at `localhost`, you need to change `localhost` to the public IP/DNS you want to access it at in `./blockscout/envs/common-frontend.env` for the following fields: `NEXT_PUBLIC_API_HOST`, `NEXT_PUBLIC_STATS_API_HOST`, `NEXT_PUBLIC_APP_HOST`, `NEXT_PUBLIC_VISUALIZE_API_HOST`.
    
-   To stop use
+   To stop everything use
+   ```bash
+   docker compose --profile reth --profile blockscout down
+   ```
+   To stop and remove volumes use
+   ```bash
+   docker compose --profile reth --profile blockscout down -v
+   ```
+
+   To stop blockscout services only use
    ```bash
    docker compose --profile blockscout down
    ```
    To stop and remove volumes use
    ```bash
    docker compose --profile blockscout down -v
+   ```
+
+   You can also quickly restart blockscout wihout impacting reth
+   ```bash
+   docker compose --profile blockscout restart
    ```

--- a/docker-compose/reth/compose.yml
+++ b/docker-compose/reth/compose.yml
@@ -32,6 +32,8 @@ services:
       --nat=publicip
       --authrpc.port=8551 --authrpc.jwtsecret=/root/jwt/jwtsecret --authrpc.addr=0.0.0.0
       --log.file.directory /root/logs
+    profiles:
+      - reth
 volumes:
   execution_data:
     driver: local


### PR DESCRIPTION
Add reth profile in docker compose to, e.g, easily restart blockscout profile without affecting reth.

## Description

Adds reth profile to docker compose and updates the readme.

## Motivation and Context

Running `docker compose --profile blockscout restart` used to restart reth as well before this change. Now, this command will restart blockscout only.

## How Has This Been Tested?

on `chain0`


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style of this project.
-   [x] My change requires a change to the documentation.
-   [x] I added deployment script (Makefile, docker file etc.)
-   [x] I have updated the documentation accordingly - Docusaurus.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
