### PR TITLE
feat: finalizeBatchWithProof with no signature

### DIFF
--- a/contracts/src/L1/rollup/IT1Chain.sol
+++ b/contracts/src/L1/rollup/IT1Chain.sol
@@ -123,6 +123,11 @@ interface IT1Chain {
     /// @notice t1 batch finalization
     ///
     /// @param withdrawRoot The withdraw trie root of current batch.
+    function finalizeBatchWithProof(bytes32 withdrawRoot) external;
+
+    /// @notice t1 batch finalization
+    ///
+    /// @param withdrawRoot The withdraw trie root of current batch.
     function finalizeBatchWithProof(bytes32 withdrawRoot, bytes calldata signature) external;
 
     /// @notice Finalize a committed batch (with blob) on layer 1.

--- a/contracts/src/L1/rollup/T1Chain.sol
+++ b/contracts/src/L1/rollup/T1Chain.sol
@@ -434,6 +434,40 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         //        bytes calldata _batchHeader,
         //        bytes32 _prevStateRoot,
         //        bytes32 _postStateRoot,
+        bytes32 _withdrawRoot
+    )
+        //        bytes calldata _aggrProof
+        external
+        override
+        whenNotPaused
+    {
+        //    ) external override OnlyProver whenNotPaused {
+        //        (uint256 batchPtr, bytes32 _batchHash, uint256 _batchIndex) = _beforeFinalizeBatch(
+        //            _batchHeader,
+        //            _postStateRoot
+        //        );
+        //        // TODO: Diego to replace following with verifying TEE signature
+        //        // verify batch
+        //        IRollupVerifier(verifier).verifyAggregateProof(0, _batchIndex, _aggrProof, _publicInputHash);
+
+        // Pop finalized and non-skipped message from L1MessageQueue.
+        //        uint256 _totalL1MessagesPoppedOverall = BatchHeaderV0Codec.getTotalL1MessagePopped(batchPtr);
+        //        _popL1MessagesMemory(
+        //            BatchHeaderV0Codec.getSkippedBitmapPtr(batchPtr),
+        //            _totalL1MessagesPoppedOverall,
+        //            BatchHeaderV0Codec.getL1MessagePopped(batchPtr)
+        //        );
+
+        //        _afterFinalizeBatch(_totalL1MessagesPoppedOverall, _batchIndex, _batchHash, _postStateRoot,
+        // _withdrawRoot);
+        _afterFinalizeBatch(0, 1, "", "", _withdrawRoot);
+    }
+
+    /// @inheritdoc IT1Chain
+    function finalizeBatchWithProof(
+        //        bytes calldata _batchHeader,
+        //        bytes32 _prevStateRoot,
+        //        bytes32 _postStateRoot,
         bytes32 _withdrawRoot,
         bytes calldata signature
     )


### PR DESCRIPTION
Temporary bring back finalizeBatchWithProof with no signature

## Description

Temporary bring back finalizeBatchWithProof with no signature to match the sprint scope and DoD

## Motivation and Context

Tasks [https://www.notion.so/t1protocol/modify-finalizeBatchWithProof-to-accept-a-whitelisted-ECDSA-sig-TEE-instead-of-a-ZKP-17d231194dc380e78075f4e2f8325784](modify finalizeBatchWithProof to accept a whitelisted ECDSA sig (TEE) instead of a ZKP) and [https://www.notion.so/t1protocol/Call-finalizeBatchWithProof-from-postman-passing-valid-signature-190231194dc38049be32d58aac4fb7a9](Call finalizeBatchWithProof from postman passing valid signature) were agreed upon before [https://www.notion.so/t1protocol/DoD-definition-18f231194dc380419b2af30a1b0d93a6](DoD definition). However, only the former task is in the current sprint and E2E flow on canary is impossible without the latter. 

To fit DoD, we agreed to bring back the former functionality on top of the new one for this sprint.

## How Has This Been Tested?

locally


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I added deployment script (Makefile, docker file etc.)
-   [ ] I have updated the documentation accordingly - Docusaurus.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
