### PR TITLE
fix: struct order in EIP-712

### DIFF
--- a/contracts/src/libraries/constants/T1Constants.sol
+++ b/contracts/src/libraries/constants/T1Constants.sol
@@ -19,11 +19,11 @@ library T1Constants {
     /// @notice The EIP-712 type definition for remaining string stub of the typehash.
     string internal constant WITNESS_TYPE_STRING =
     // solhint-disable-next-line max-line-length
-        "Witness witness)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)TokenPermissions(address token,uint256 amount)";
+        "Witness witness)TokenPermissions(address token,uint256 amount)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)";
 
     /// @notice The full EIP-712 type definition for the witness the typehash.
     bytes32 internal constant FULL_WITNESS_TYPEHASH = keccak256(
         // solhint-disable-next-line max-line-length
-        "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)TokenPermissions(address token,uint256 amount)"
+        "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)"
     );
 }


### PR DESCRIPTION
Fixes the order of structs according to EIP-712

## Description

Changing the order of structs

## Motivation and Context

It complies with the standard order of structs in EIP-712. This standard is required by permit2 sdk

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I added deployment script (Makefile, docker file etc.)
-   [ ] I have updated the documentation accordingly - Docusaurus.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.
