### PR TITLE
Fix: Add permissions to allow L1 Security Council to call setL2BaseFee

### DIFF
--- a/contracts/script/deploy/InitializeL1T1Owner.s.sol
+++ b/contracts/script/deploy/InitializeL1T1Owner.s.sol
@@ -13,6 +13,7 @@ import { L1MessageQueue } from "../../src/L1/rollup/L1MessageQueue.sol";
 import { T1MessengerBase } from "../../src/libraries/T1MessengerBase.sol";
 import { L2GasPriceOracle } from "../../src/L1/rollup/L2GasPriceOracle.sol";
 import { MultipleVersionRollupVerifier } from "../../src/L1/rollup/MultipleVersionRollupVerifier.sol";
+import { L1MessageQueueWithGasPriceOracle } from "../../src/L1/rollup/L1MessageQueueWithGasPriceOracle.sol";
 import { T1Chain } from "../../src/L1/rollup/T1Chain.sol";
 import { T1Owner } from "../../src/misc/T1Owner.sol";
 import { Whitelist } from "../../src/L2/predeploys/Whitelist.sol";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Add call to `updateAccess` with `setL2BaseFee`
<!--- Describe your changes in detail -->

## Motivation and Context
In order to enable security council to call `setL2BaseFee`
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Not tested. Will test in next deployment
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I added deployment script (Makefile, docker file etc.)
-   [ ] I have updated the documentation accordingly - Docusaurus.
-   [ ] I have added tests to cover my changes.
-   [ ] All new and existing tests passed.
