### PR TITLE
fix: encode witness using typehash

### DIFF
--- a/contracts/script/test/SwapERC20.s.sol
+++ b/contracts/script/test/SwapERC20.s.sol
@@ -52,11 +52,12 @@ contract SwapERC20 is Script, PermitSignature {
             outputTokenAmount: outputTokenAmount
         });
 
-        bytes32 witnessEncoded = keccak256(abi.encode(witness));
+        bytes32 witnessEncoded = keccak256(abi.encode(T1Constants.WITNESS_TYPEHASH, witness));
+
         bytes memory sig = getPermitWitnessTransferSignature(
             permit,
             ALICE_PRIVATE_KEY,
-            T1Constants.FULL_WITNESS_TYPEHASH,
+            T1Constants.FULL_PERMITWITNESSTRANSFERFROM_TYPEHASH,
             witnessEncoded,
             ISignatureTransfer(permit2).DOMAIN_SEPARATOR(),
             L1_GATEWAY_ROUTER_PROXY_ADDR

--- a/contracts/src/L1/gateways/L1GatewayRouter.sol
+++ b/contracts/src/L1/gateways/L1GatewayRouter.sol
@@ -162,7 +162,7 @@ contract L1GatewayRouter is OwnableUpgradeable, IL1GatewayRouter {
         require(params.witness.outputTokenAmount <= outputTokenBalance, "Insufficient reserves");
 
         // Encoded witness data to be included when checking the user signature
-        bytes32 witness = keccak256(abi.encode(params.witness));
+        bytes32 witness = keccak256(abi.encode(T1Constants.WITNESS_TYPEHASH, params.witness));
 
         // Use Permit2 to validate and transfer input tokens from `owner` to the defaultERC20Gateway
         ISignatureTransfer(permit2).permitWitnessTransferFrom(

--- a/contracts/src/libraries/constants/T1Constants.sol
+++ b/contracts/src/libraries/constants/T1Constants.sol
@@ -16,14 +16,20 @@ library T1Constants {
     /// @notice Chain ID of the T1 devnet
     uint64 internal constant T1_DEVNET_CHAIN_ID = 299_792;
 
-    /// @notice The EIP-712 type definition for remaining string stub of the typehash.
+    /// @notice The EIP-712 type string for the remaining after the witness.
     string internal constant WITNESS_TYPE_STRING =
     // solhint-disable-next-line max-line-length
         "Witness witness)TokenPermissions(address token,uint256 amount)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)";
 
-    /// @notice The full EIP-712 type definition for the witness the typehash.
-    bytes32 internal constant FULL_WITNESS_TYPEHASH = keccak256(
+    /// @notice The full EIP-712 type definition for the PermitWitnessTransferFrom typehash.
+    bytes32 internal constant FULL_PERMITWITNESSTRANSFERFROM_TYPEHASH = keccak256(
         // solhint-disable-next-line max-line-length
         "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,Witness witness)TokenPermissions(address token,uint256 amount)Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)"
+    );
+
+    /// @notice The EIP-712 type definition for the witness typehash.
+    bytes32 internal constant WITNESS_TYPEHASH = keccak256(
+        // solhint-disable-next-line max-line-length
+        "Witness(uint8 direction,uint256 priceAfterSlippage,address outputTokenAddress,uint256 outputTokenAmount)"
     );
 }

--- a/contracts/src/test/7683/BaseTest.sol
+++ b/contracts/src/test/7683/BaseTest.sol
@@ -208,7 +208,7 @@ contract BaseTest is Test, DeployPermit2 {
 
     bytes32 constant _TOKEN_PERMISSIONS_TYPEHASH = keccak256("TokenPermissions(address token,uint256 amount)");
 
-    bytes32 constant FULL_WITNESS_TYPEHASH = keccak256(
+    bytes32 constant FULL_PERMITWITNESSTRANSFERFROM_TYPEHASH = keccak256(
         // solhint-disable-next-line max-line-length
         "PermitWitnessTransferFrom(TokenPermissions permitted,address spender,uint256 nonce,uint256 deadline,ResolvedCrossChainOrder witness)ResolvedCrossChainOrder(address user, uint64 originChainId, uint32 openDeadline, uint32 fillDeadline, Output[] maxSpent, Output[] minReceived, FillInstruction[] fillInstructions)Output(bytes32 token, uint256 amount, bytes32 recipient, uint64 chainId)FillInstruction(uint64 destinationChainId, bytes32 destinationSettler, bytes originData)"
     );

--- a/contracts/src/test/L1GatewayRouter.t.sol
+++ b/contracts/src/test/L1GatewayRouter.t.sol
@@ -235,11 +235,12 @@ contract L1GatewayRouterTest is L1GatewayTestBase, DeployPermit2, PermitSignatur
         params.permit.permitted.amount = inputTokenAmount;
         params.witness.outputTokenAmount = outputTokenAmount;
 
-        bytes32 witnessEncoded = keccak256(abi.encode(params.witness));
+        bytes32 witnessEncoded = keccak256(abi.encode(T1Constants.WITNESS_TYPEHASH, params.witness));
+
         bytes memory sig = getPermitWitnessTransferSignature(
             params.permit,
             alicePrivateKey,
-            T1Constants.FULL_WITNESS_TYPEHASH,
+            T1Constants.FULL_PERMITWITNESSTRANSFERFROM_TYPEHASH,
             witnessEncoded,
             ISignatureTransfer(permit2).DOMAIN_SEPARATOR(),
             address(router)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

[Permit2-sdk](https://github.com/Uniswap/sdks/blob/a7fb8d7b8eecdc8a29d386420339da86b0361a77/sdks/permit2-sdk/test/mock/MockWitness.sol#L12) that is used by tdex UI encodes the witness using the typehash. We were following the way that `permit2` library uses in their [tests](https://github.com/Uniswap/permit2/blob/cc56ad0f3439c502c246fc5cfcc3db92bb8b7219/test/SignatureTransfer.t.sol#L535) which doesn't encode with the typehash.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`forge test --match-test testSwapERC20`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] My code follows the code style of this project.
-   [x] I added deployment script (Makefile, docker file etc.)
-   [x] All new and existing tests passed.
