### PR TITLE
Fix: Correct USDT decimals to real 6

### DIFF
--- a/contracts/script/deploy/DeployL1Usdt.s.sol
+++ b/contracts/script/deploy/DeployL1Usdt.s.sol
@@ -14,6 +14,15 @@ contract Usdt is ERC20 {
     constructor(uint256 initialSupply) ERC20("USDT", "USDT") {
         _mint(msg.sender, initialSupply);
     }
+
+    /**
+     * @notice Returns the number of decimals used to get user representation.
+     * @dev Override the default OpenZeppelin ERC20 decimals() to match USDT standard (6 decimals).
+     * @return uint8 The number of decimals (6).
+     */
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
 }
 
 contract DeployL1Usdt is Script, DeploymentUtils {
@@ -22,7 +31,7 @@ contract DeployL1Usdt is Script, DeploymentUtils {
 
         uint256 L1_DEPLOYER_PRIVATE_KEY = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
         vm.startBroadcast(L1_DEPLOYER_PRIVATE_KEY);
-        Usdt usdt = new Usdt(1_000_000 * 10 ** 18);
+        Usdt usdt = new Usdt(1_000_000 * 1e6);
         vm.stopBroadcast();
 
         logAddress("L1_USDT_ADDR", address(usdt));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Deploy USDT with 6 decimals.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

L1 & L2 USDT decimal places being 18 instead of 6 cause integration problems with T-DEX.

## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [x] The version has been bumped according to our internal semantic versioning rules˚¬˚