### PR TITLE
fix: bump ETH granted to L2T1Messenger to 300k

### DIFF
--- a/contracts/script/deploy/DeployL2BridgeProxyPlaceholder.s.sol
+++ b/contracts/script/deploy/DeployL2BridgeProxyPlaceholder.s.sol
@@ -52,7 +52,7 @@ contract DeployL2BridgeProxyPlaceholder is Script, DeploymentUtils {
     }
 
     function deployL2T1Messenger() internal {
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy{ value: 1000 ether }(
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy{ value: 300000 ether }(
             address(placeholder), address(proxyAdmin), new bytes(0)
         );
 

--- a/contracts/script/deploy/DeployL2BridgeProxyPlaceholder.s.sol
+++ b/contracts/script/deploy/DeployL2BridgeProxyPlaceholder.s.sol
@@ -52,7 +52,7 @@ contract DeployL2BridgeProxyPlaceholder is Script, DeploymentUtils {
     }
 
     function deployL2T1Messenger() internal {
-        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy{ value: 300000 ether }(
+        TransparentUpgradeableProxy proxy = new TransparentUpgradeableProxy{ value: 300_000 ether }(
             address(placeholder), address(proxyAdmin), new bytes(0)
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Increases ETH allowance to `L2T1Messenger` when deploying it.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] This change includes any required documentation updates.
-   [ ] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [ ] This change includes any required test coverage.
-   [ ] The version has been bumped according to our internal semantic versioning rules˚¬˚

˚¬˚ Semantic versioning rules:
* Patch (i.e. 0.0.1) bumped if this change requires a redeployment/upgrade of contracts
* Minor (i.e. 0.1.0) bumped if this change requires a new network deployment/hard fork
* Major (i.e. 1.0.0) bumped if this change means we have achieved escape velocity