### PR TITLE
Feature: dynamic batch indices

### DIFF
--- a/contracts/src/L1/rollup/IT1Chain.sol
+++ b/contracts/src/L1/rollup/IT1Chain.sol
@@ -117,9 +117,10 @@ interface IT1Chain {
 
     /// @notice t1 batch finalization
     ///
-    /// @param withdrawRoot The withdraw trie root of current batch.
-    /// @param signature The ECDSA valid signature to match one of the provers
-    function finalizeBatchWithProof(bytes32 withdrawRoot, bytes calldata signature) external;
+    /// @param _batchIndex The index of the current batch.
+    /// @param _withdrawRoot The withdraw trie root of current batch.
+    /// @param _signature The ECDSA valid signature to match one of the provers
+    function finalizeBatchWithProof(uint256 _batchIndex, bytes32 _withdrawRoot, bytes calldata _signature) external;
 
     /// @notice Finalize a committed batch (with blob) on layer 1.
     ///

--- a/contracts/src/L1/rollup/T1Chain.sol
+++ b/contracts/src/L1/rollup/T1Chain.sol
@@ -426,18 +426,17 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
 
     /// @inheritdoc IT1Chain
     function finalizeBatchWithProof(
-        //        bytes calldata _batchHeader,
+        uint256 _batchIndex,
         //        bytes32 _prevStateRoot,
         //        bytes32 _postStateRoot,
         bytes32 _withdrawRoot,
-        bytes calldata signature
+        bytes calldata _signature
     )
         //        bytes calldata _aggrProof
         external
         override
         whenNotPaused
     {
-        //    ) external override OnlyProver whenNotPaused {
         //        (uint256 batchPtr, bytes32 _batchHash, uint256 _batchIndex) = _beforeFinalizeBatch(
         //            _batchHeader,
         //            _postStateRoot
@@ -457,13 +456,13 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         //        _afterFinalizeBatch(_totalL1MessagesPoppedOverall, _batchIndex, _batchHash, _postStateRoot,
         // _withdrawRoot);
         // Basic sanity check
-        if (signature.length != 65) revert ErrorIncorrectSignatureLength();
+        if (_signature.length != 65) revert ErrorIncorrectSignatureLength();
 
         // Hash the message with the standard Ethereum Signed Message prefix
         bytes32 ethSignedMessageHash = _withdrawRoot.toEthSignedMessageHash();
 
         // Recover the signer from the signature
-        address signer = ethSignedMessageHash.recover(signature);
+        address signer = ethSignedMessageHash.recover(_signature);
 
         // Verify that the recovered signer matches a prover
         if (!isProver[signer]) {
@@ -471,7 +470,7 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         }
 
         // Now that the signature is verified, perform your internal logic
-        _afterFinalizeBatch(0, 1, "", "", _withdrawRoot);
+        _afterFinalizeBatch(0, _batchIndex, "", "", _withdrawRoot);
     }
 
     /// @inheritdoc IT1Chain

--- a/contracts/src/L1/rollup/T1Chain.sol
+++ b/contracts/src/L1/rollup/T1Chain.sol
@@ -718,11 +718,11 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
     )
         internal
     {
-        //        // check and update lastFinalizedBatchIndex
-        //        unchecked {
-        //            if (lastFinalizedBatchIndex + 1 != _batchIndex) revert ErrorIncorrectBatchIndex();
-        lastFinalizedBatchIndex = _batchIndex;
-        //        }
+        // check and update lastFinalizedBatchIndex
+        unchecked {
+            if (lastFinalizedBatchIndex + 1 != _batchIndex) revert ErrorIncorrectBatchIndex();
+            lastFinalizedBatchIndex = _batchIndex;
+        }
 
         //        // record state root and withdraw root
         //        finalizedStateRoots[_batchIndex] = _postStateRoot;

--- a/contracts/src/test/T1Chain.t.sol
+++ b/contracts/src/test/T1Chain.t.sol
@@ -1671,7 +1671,7 @@ contract T1ChainTest is Test {
         bytes memory invalidSig = new bytes(64); // 64 bytes, not 65
 
         vm.expectRevert(T1Chain.ErrorIncorrectSignatureLength.selector);
-        rollup.finalizeBatchWithProof(dummyRoot, invalidSig);
+        rollup.finalizeBatchWithProof(0, dummyRoot, invalidSig);
     }
 
     /**
@@ -1688,7 +1688,7 @@ contract T1ChainTest is Test {
         vm.expectRevert(abi.encodeWithSelector(T1Chain.ErrorIncorrectSigner.selector, expectedBadSigner));
 
         // This call should revert with `ErrorIncorrectSigner(badSigner)`
-        rollup.finalizeBatchWithProof(dummyRoot, sig);
+        rollup.finalizeBatchWithProof(0, dummyRoot, sig);
     }
 
     /**
@@ -1703,10 +1703,11 @@ contract T1ChainTest is Test {
         bytes memory sig = _signWithdrawRoot(VALID_SIGNER_KEY, withdrawRoot);
 
         // Expect it to succeed
-        rollup.finalizeBatchWithProof(withdrawRoot, sig);
+        uint256 batchIndex = 1;
+        rollup.finalizeBatchWithProof(batchIndex, withdrawRoot, sig);
 
-        assertEq(rollup.lastFinalizedBatchIndex(), 1);
-        assertEq(rollup.withdrawRoots(1), withdrawRoot);
+        assertEq(rollup.lastFinalizedBatchIndex(), batchIndex);
+        assertEq(rollup.withdrawRoots(batchIndex), withdrawRoot);
     }
 
     /**
@@ -1720,6 +1721,6 @@ contract T1ChainTest is Test {
         bytes memory sig = _signWithdrawRoot(VALID_SIGNER_KEY, dummyRoot);
 
         vm.expectRevert(bytes("Pausable: paused"));
-        rollup.finalizeBatchWithProof(dummyRoot, sig);
+        rollup.finalizeBatchWithProof(0, dummyRoot, sig);
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* `T1Chain.sol`: pass dynamic batchIndex to `finalizeBatchWithProof`
<!--- Describe your changes in detail -->

## Motivation and Context
To prepare for users self claiming their withdrawals
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
It hasn't. Should be tested along with [PR in Postman](https://github.com/t1protocol/postman/pull/24)
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] This change includes any required documentation updates.
-   [x] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [x] This change includes any required test coverage.