### PR TITLE
Feat: Verify Proof Of Fill before 7683 settlement

### DIFF
--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -64,14 +64,14 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @param _origin The origin domain
     /// @param _sender The sender address
     /// @param _batchIndex The index of the batch where the PoF belongs to
-    /// @param _proofOfFillMerkleProof The proof of fill Merkle root
+    /// @param _intentFilledMerkleProof The intent filled Merkle proof
     /// @param _nonce The nonce of the message
     /// @param _message The message
     function handle(
         uint32 _origin,
         bytes32 _sender,
         uint256 _batchIndex,
-        bytes calldata _proofOfFillMerkleProof,
+        bytes calldata _intentFilledMerkleProof,
         uint256 _nonce,
         bytes calldata _message
     )
@@ -79,7 +79,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
         payable
         onlyMessenger
     {
-        _handle(_origin, _sender, _batchIndex, _proofOfFillMerkleProof, _nonce, _message);
+        _handle(_origin, _sender, _batchIndex, _intentFilledMerkleProof, _nonce, _message);
     }
 
     // ============ Internal Functions ============
@@ -123,14 +123,14 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @param _messageOrigin The domain from which the message originates
     /// @param _messageSender The address of the sender on the origin domain
     /// @param _batchIndex The index of the batch where the PoF belongs to
-    /// @param _proofOfFillMerkleProof The proof of fill merkle root
+    /// @param _intentFilledMerkleProof The intent filled Merkle proof
     /// @param _nonce The nonce of the message
     /// @param _message The encoded message received via t1
     function _handle(
         uint32 _messageOrigin,
         bytes32 _messageSender,
         uint256 _batchIndex,
-        bytes calldata _proofOfFillMerkleProof,
+        bytes calldata _intentFilledMerkleProof,
         uint256 _nonce,
         bytes calldata _message
     )
@@ -146,10 +146,10 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
 
         if (
             !WithdrawTrieVerifier.verifyMerkleProof(
-                t1Chain.proofOfFill7683Roots(_batchIndex),
+                t1Chain.intentFilledMerkleProofs(_batchIndex),
                 keccak256(abi.encode(_settle, _orderIds, _ordersFillerData)),
                 _nonce,
-                _proofOfFillMerkleProof
+                _intentFilledMerkleProof
             )
         ) {
             revert InvalidProof();

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -39,7 +39,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
 
     // ============ Errors ============
     error OnlyMessenger();
-    error FunctionNotImplemented(string functionName);
     error EthNotAllowed();
     error BatchNotFinalized();
     error IntentProofNotFound(uint256 batchIndex, bytes32 proofOfFillRoot);
@@ -140,9 +139,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
         internal
     {
         IT1Chain t1Chain = IT1Chain(IL1T1Messenger(address(messenger)).rollup());
-
-        console.log("xxxx", _intentProof.batchIndex);
-        console.logBytes32(_intentProof.proofOfFillRoot);
 
         // Check if intent proof batch index is finalized
         if (!t1Chain.isBatchFinalized(_intentProof.batchIndex)) revert BatchNotFinalized();

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { console } from "forge-std/console.sol";
-
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Hyperlane7683Message } from "intents-framework/libs/Hyperlane7683Message.sol";
 import { BasicSwap7683 } from "intents-framework/BasicSwap7683.sol";

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -10,6 +10,7 @@ import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
 import { IT1Chain } from "../L1/rollup/IT1Chain.sol";
 import { IL1T1Messenger } from "../L1/IL1T1Messenger.sol";
+import { WithdrawTrieVerifier } from "../libraries/verifier/WithdrawTrieVerifier.sol";
 
 /**
  * @title T1ERC7683
@@ -24,15 +25,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     IL1T1Messenger public immutable messenger;
     address public counterpart;
 
-    // ============ Structs ============
-    /// @notice Struct to represent an example order
-    struct IntentProof {
-        // The index of the batch where the PoF belongs to.
-        uint256 batchIndex;
-        // The proof of fill trie root
-        bytes32 proofOfFillRoot;
-    }
-
     // ============ Upgrade Gap ============
     /// @dev Reserved storage slots for upgradeability.
     uint256[47] private __GAP;
@@ -44,6 +36,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     error IntentProofNotFound(uint256 batchIndex, bytes32 proofOfFillRoot);
     error SettlementFailed();
     error RefundFailed();
+    error InvalidProof();
 
     // ============ Modifiers ============
     modifier onlyMessenger() {
@@ -73,19 +66,23 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @notice Handles an incoming message
     /// @param _origin The origin domain
     /// @param _sender The sender address
-    /// @param _intentProof The intent proof containing the batch index and proof of fill root
+    /// @param _batchIndex The index of the batch where the PoF belongs to
+    /// @param _proofOfFillMerkleProof The proof of fill Merkle root
+    /// @param _nonce The nonce of the message
     /// @param _message The message
     function handle(
         uint32 _origin,
         bytes32 _sender,
-        IntentProof calldata _intentProof,
+        uint256 _batchIndex,
+        bytes calldata _proofOfFillMerkleProof,
+        uint256 _nonce,
         bytes calldata _message
     )
         external
         payable
         onlyMessenger
     {
-        _handle(_origin, _sender, _intentProof, _message);
+        _handle(_origin, _sender, _batchIndex, _proofOfFillMerkleProof, _nonce, _message);
     }
 
     // ============ Internal Functions ============
@@ -128,12 +125,16 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @dev Decodes the message and processes settlement or refund operations accordingly
     /// @param _messageOrigin The domain from which the message originates
     /// @param _messageSender The address of the sender on the origin domain
-    /// @param _intentProof The intent proof containing the batch index and proof of fill root
+    /// @param _batchIndex The index of the batch where the PoF belongs to
+    /// @param _proofOfFillMerkleProof The proof of fill merkle root
+    /// @param _nonce The nonce of the message
     /// @param _message The encoded message received via t1
     function _handle(
         uint32 _messageOrigin,
         bytes32 _messageSender,
-        IntentProof calldata _intentProof,
+        uint256 _batchIndex,
+        bytes calldata _proofOfFillMerkleProof,
+        uint256 _nonce,
         bytes calldata _message
     )
         internal
@@ -141,15 +142,28 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
         IT1Chain t1Chain = IT1Chain(IL1T1Messenger(address(messenger)).rollup());
 
         // Check if intent proof batch index is finalized
-        if (!t1Chain.isBatchFinalized(_intentProof.batchIndex)) revert BatchNotFinalized();
+        if (!t1Chain.isBatchFinalized(_batchIndex)) revert BatchNotFinalized();
+
+        bytes32 _proofOfFillRoot = t1Chain.proofOfFill7683Roots(_batchIndex);
 
         // Check intent proof exists in our rollup
-        if (t1Chain.proofOfFill7683Roots(_intentProof.batchIndex) != _intentProof.proofOfFillRoot) {
-            revert IntentProofNotFound(_intentProof.batchIndex, _intentProof.proofOfFillRoot);
+        if (_proofOfFillRoot != _proofOfFillRoot) {
+            revert IntentProofNotFound(_batchIndex, _proofOfFillRoot);
         }
 
         (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
             Hyperlane7683Message.decode(_message);
+
+        if (
+            !WithdrawTrieVerifier.verifyMerkleProof(
+                _proofOfFillRoot,
+                keccak256(abi.encode(_settle, _orderIds, _ordersFillerData)),
+                _nonce,
+                _proofOfFillMerkleProof
+            )
+        ) {
+            revert InvalidProof();
+        }
 
         for (uint256 i = 0; i < _orderIds.length; i++) {
             if (_settle) {

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -31,7 +31,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     error OnlyMessenger();
     error EthNotAllowed();
     error BatchNotFinalized();
-    error IntentProofNotFound(uint256 batchIndex, bytes32 proofOfFillRoot);
     error SettlementFailed();
     error RefundFailed();
     error InvalidProof();
@@ -142,19 +141,12 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
         // Check if intent proof batch index is finalized
         if (!t1Chain.isBatchFinalized(_batchIndex)) revert BatchNotFinalized();
 
-        bytes32 _proofOfFillRoot = t1Chain.proofOfFill7683Roots(_batchIndex);
-
-        // Check intent proof exists in our rollup
-        if (_proofOfFillRoot != _proofOfFillRoot) {
-            revert IntentProofNotFound(_batchIndex, _proofOfFillRoot);
-        }
-
         (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
             Hyperlane7683Message.decode(_message);
 
         if (
             !WithdrawTrieVerifier.verifyMerkleProof(
-                _proofOfFillRoot,
+                t1Chain.proofOfFill7683Roots(_batchIndex),
                 keccak256(abi.encode(_settle, _orderIds, _ordersFillerData)),
                 _nonce,
                 _proofOfFillMerkleProof

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { console } from "forge-std/console.sol";
+
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { Hyperlane7683Message } from "intents-framework/libs/Hyperlane7683Message.sol";
 import { BasicSwap7683 } from "intents-framework/BasicSwap7683.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
-import { IT1Messenger } from "../libraries/IT1Messenger.sol";
+import { IT1Chain } from "../L1/rollup/IT1Chain.sol";
+import { IL1T1Messenger } from "../L1/IL1T1Messenger.sol";
 
 /**
  * @title T1ERC7683
@@ -18,8 +21,17 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     // ============ Constants ============
     uint32 internal constant DEFAULT_GAS_LIMIT = 1_000_000;
     uint32 public immutable localDomain;
-    IT1Messenger public immutable messenger;
+    IL1T1Messenger public immutable messenger;
     address public counterpart;
+
+    // ============ Structs ============
+    /// @notice Struct to represent an example order
+    struct IntentProof {
+        // The index of the batch where the PoF belongs to.
+        uint256 batchIndex;
+        // The proof of fill trie root
+        bytes32 proofOfFillRoot;
+    }
 
     // ============ Upgrade Gap ============
     /// @dev Reserved storage slots for upgradeability.
@@ -29,6 +41,8 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     error OnlyMessenger();
     error FunctionNotImplemented(string functionName);
     error EthNotAllowed();
+    error BatchNotFinalized();
+    error IntentProofNotFound(uint256 batchIndex, bytes32 proofOfFillRoot);
     error SettlementFailed();
     error RefundFailed();
 
@@ -45,7 +59,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @param _permit2 The address of the permit2 contract.
     /// @param localDomain_ The local domain.
     constructor(address _messenger, address _permit2, uint32 localDomain_) BasicSwap7683(_permit2) {
-        messenger = IT1Messenger(_messenger);
+        messenger = IL1T1Messenger(_messenger);
         localDomain = localDomain_;
     }
 
@@ -60,9 +74,19 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @notice Handles an incoming message
     /// @param _origin The origin domain
     /// @param _sender The sender address
+    /// @param _intentProof The intent proof containing the batch index and proof of fill root
     /// @param _message The message
-    function handle(uint32 _origin, bytes32 _sender, bytes calldata _message) external payable onlyMessenger {
-        _handle(_origin, _sender, _message);
+    function handle(
+        uint32 _origin,
+        bytes32 _sender,
+        IntentProof calldata _intentProof,
+        bytes calldata _message
+    )
+        external
+        payable
+        onlyMessenger
+    {
+        _handle(_origin, _sender, _intentProof, _message);
     }
 
     // ============ Internal Functions ============
@@ -105,8 +129,29 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @dev Decodes the message and processes settlement or refund operations accordingly
     /// @param _messageOrigin The domain from which the message originates
     /// @param _messageSender The address of the sender on the origin domain
+    /// @param _intentProof The intent proof containing the batch index and proof of fill root
     /// @param _message The encoded message received via t1
-    function _handle(uint32 _messageOrigin, bytes32 _messageSender, bytes calldata _message) internal {
+    function _handle(
+        uint32 _messageOrigin,
+        bytes32 _messageSender,
+        IntentProof calldata _intentProof,
+        bytes calldata _message
+    )
+        internal
+    {
+        IT1Chain t1Chain = IT1Chain(IL1T1Messenger(address(messenger)).rollup());
+
+        console.log("xxxx", _intentProof.batchIndex);
+        console.logBytes32(_intentProof.proofOfFillRoot);
+
+        // Check if intent proof batch index is finalized
+        if (!t1Chain.isBatchFinalized(_intentProof.batchIndex)) revert BatchNotFinalized();
+
+        // Check intent proof exists in our rollup
+        if (t1Chain.proofOfFill7683Roots(_intentProof.batchIndex) != _intentProof.proofOfFillRoot) {
+            revert IntentProofNotFound(_intentProof.batchIndex, _intentProof.proofOfFillRoot);
+        }
+
         (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
             Hyperlane7683Message.decode(_message);
 

--- a/contracts/src/L1/IL1T1Messenger.sol
+++ b/contracts/src/L1/IL1T1Messenger.sol
@@ -30,6 +30,15 @@ interface IL1T1Messenger is IT1Messenger {
 
     /**
      *
+     * Public View Functions *
+     *
+     */
+
+    /// @notice Return the address of the rollup.
+    function rollup() external view returns (address);
+
+    /**
+     *
      * Public Mutating Functions *
      *
      */

--- a/contracts/src/L1/rollup/IT1Chain.sol
+++ b/contracts/src/L1/rollup/IT1Chain.sol
@@ -65,8 +65,8 @@ interface IT1Chain {
     function withdrawRoots(uint256 batchIndex) external view returns (bytes32);
 
     /// @param batchIndex The index of the batch.
-    /// @return The proof of fill merkle trie root of a committed batch.
-    function proofOfFill7683Roots(uint256 batchIndex) external view returns (bytes32);
+    /// @return The intent filled Merkle trie proof of a committed batch.
+    function intentFilledMerkleProofs(uint256 batchIndex) external view returns (bytes32);
 
     /// @param batchIndex The index of the batch.
     /// @return Whether the batch is finalized by batch index.
@@ -124,14 +124,15 @@ interface IT1Chain {
     /// @param batchIndex The index of the current batch.
     /// @param withdrawRoot The withdraw trie root of current batch.
     /// @param withdrawRootSignature The ECDSA valid signature of withdraw root to match one of the provers
-    /// @param proofOfFill7683Root 7683 The Proof of Fill trie root of current batch.
-    /// @param proofOfFillRootSignature The ECDSA valid signature of proof of fill root to match one of the provers
+    /// @param intentFilledMerkleProof Intent filled Merkle proof of current batch.
+    /// @param iintentFilledMerkleProofSignature The ECDSA valid signature of intent filled Merkle proof to match one of
+    /// the provers
     function finalizeBatchWithProof(
         uint256 batchIndex,
         bytes32 withdrawRoot,
         bytes calldata withdrawRootSignature,
-        bytes32 proofOfFill7683Root,
-        bytes calldata proofOfFillRootSignature
+        bytes32 intentFilledMerkleProof,
+        bytes calldata iintentFilledMerkleProofSignature
     )
         external;
 

--- a/contracts/src/L1/rollup/T1Chain.sol
+++ b/contracts/src/L1/rollup/T1Chain.sol
@@ -167,7 +167,7 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
     mapping(uint256 => bytes32) public override withdrawRoots;
 
     /// @inheritdoc IT1Chain
-    mapping(uint256 => bytes32) public override proofOfFill7683Roots;
+    mapping(uint256 => bytes32) public override intentFilledMerkleProofs;
     /**
      *
      * Function Modifiers *
@@ -434,8 +434,8 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         //        bytes32 _postStateRoot,
         bytes32 _withdrawRoot,
         bytes calldata withdrawRootSignature,
-        bytes32 _proofOfFill7683Root,
-        bytes calldata proofOfFillRootSignature
+        bytes32 _intentFilledMerkleProof,
+        bytes calldata intentFilledMerkleProofSignature
     )
         //        bytes calldata _aggrProof
         external
@@ -460,10 +460,10 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         //        _afterFinalizeBatch(_totalL1MessagesPoppedOverall, _batchIndex, _batchHash, _postStateRoot,
         // _withdrawRoot);
         _checkSignedByProver(withdrawRootSignature, _withdrawRoot);
-        _checkSignedByProver(proofOfFillRootSignature, _proofOfFill7683Root);
+        _checkSignedByProver(intentFilledMerkleProofSignature, _intentFilledMerkleProof);
 
         // Now that the signature is verified, perform your internal logic
-        _afterFinalizeBatch(0, batchIndex, "", "", _withdrawRoot, _proofOfFill7683Root);
+        _afterFinalizeBatch(0, batchIndex, "", "", _withdrawRoot, _intentFilledMerkleProof);
     }
 
     /// @inheritdoc IT1Chain
@@ -707,14 +707,14 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
     /// @param _batchHash The hash of current batch.
     /// @param _postStateRoot The state root after current batch.
     /// @param _withdrawRoot The withdraw trie root after current batch.
-    /// @param _proofOfFill7683Root The proof of fill trie root after current batch.
+    /// @param _intentFilledMerkleProof The intent filled Merkle proof after current batch.
     function _afterFinalizeBatch(
         uint256, /*_totalL1MessagesPoppedOverall*/
         uint256 _batchIndex,
         bytes32 _batchHash,
         bytes32 _postStateRoot,
         bytes32 _withdrawRoot,
-        bytes32 _proofOfFill7683Root
+        bytes32 _intentFilledMerkleProof
     )
         internal
     {
@@ -727,7 +727,7 @@ contract T1Chain is OwnableUpgradeable, PausableUpgradeable, IT1Chain {
         //        // record state root and withdraw root
         //        finalizedStateRoots[_batchIndex] = _postStateRoot;
         withdrawRoots[_batchIndex] = _withdrawRoot;
-        proofOfFill7683Roots[_batchIndex] = _proofOfFill7683Root;
+        intentFilledMerkleProofs[_batchIndex] = _intentFilledMerkleProof;
 
         //        // Pop finalized and non-skipped message from L1MessageQueue.
         //        _finalizePoppedL1Messages(_totalL1MessagesPoppedOverall);

--- a/contracts/src/mocks/T1ChainMockBlob.sol
+++ b/contracts/src/mocks/T1ChainMockBlob.sol
@@ -50,8 +50,8 @@ contract T1ChainMockBlob is T1Chain {
         overrideBatchHashCheck = status;
     }
 
-    function setProofOfFill7683Root(uint256 _batchIndex, bytes32 _proofOfFill7683Root) external {
-        proofOfFill7683Roots[_batchIndex] = _proofOfFill7683Root;
+    function setIntentFilledMerkleProof(uint256 _batchIndex, bytes32 _intentFilledMerkleProof) external {
+        intentFilledMerkleProofs[_batchIndex] = _intentFilledMerkleProof;
     }
 
     /**

--- a/contracts/src/mocks/T1ChainMockBlob.sol
+++ b/contracts/src/mocks/T1ChainMockBlob.sol
@@ -30,11 +30,6 @@ contract T1ChainMockBlob is T1Chain {
         T1Chain(_chainId, _messageQueue, _verifier)
     { }
 
-    /**
-     *
-     * Internal Functions *
-     *
-     */
     function setBlobVersionedHash(bytes32 _blobVersionedHash) external {
         blobVersionedHash = _blobVersionedHash;
     }
@@ -55,6 +50,15 @@ contract T1ChainMockBlob is T1Chain {
         overrideBatchHashCheck = status;
     }
 
+    function setProofOfFill7683Root(uint256 _batchIndex, bytes32 _proofOfFill7683Root) external {
+        proofOfFill7683Roots[_batchIndex] = _proofOfFill7683Root;
+    }
+
+    /**
+     *
+     * Internal Functions *
+     *
+     */
     function _getBlobVersionedHash() internal virtual override returns (bytes32 _blobVersionedHash) {
         _blobVersionedHash = blobVersionedHash;
     }

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -296,7 +296,8 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         uint256[] memory balancesBeforeSettle = _balances(inputToken);
-        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
+        bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterSettle = _balances(inputToken);
 
@@ -340,8 +341,9 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         vm.recordLogs();
+        bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
         // wrongly set origin instead of destination
-        _handleRelayMessage(orderIds, ordersFillerData, true, origin, 1);
+        _handleRelayMessage(origin, 1, innerMessage, keccak256(innerMessage));
         Vm.Log[] memory _logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < _logs.length; i++) {
             Vm.Log memory _log = _logs[i];
@@ -422,8 +424,8 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         uint256[] memory balancesBeforeSettle = _balances();
-
-        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
+        bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterSettle = _balances();
 
@@ -516,8 +518,8 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         uint256[] memory balancesBeforeSettle = _balances(inputToken);
-
-        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
+        bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterSettle = _balances(inputToken);
 
@@ -582,8 +584,8 @@ contract T1BasicSwapE2E is BaseTest {
 
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
-
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
+        bytes memory innerMessage = abi.encode(false, orderIds, emptyOrdersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterRefund = _balances(inputToken);
 
@@ -618,8 +620,9 @@ contract T1BasicSwapE2E is BaseTest {
         emptyOrdersFillerData[0] = hex"";
 
         vm.recordLogs();
+        bytes memory innerMessage = abi.encode(false, orderIds, emptyOrdersFillerData);
         // wrongly set origin instead of destination
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, origin, 1);
+        _handleRelayMessage(origin, 1, innerMessage, keccak256(innerMessage));
         Vm.Log[] memory _logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < _logs.length; i++) {
             Vm.Log memory _log = _logs[i];
@@ -684,8 +687,8 @@ contract T1BasicSwapE2E is BaseTest {
 
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
-
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
+        bytes memory innerMessage = abi.encode(false, orderIds, emptyOrdersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterRefund = _balances();
 
@@ -761,8 +764,8 @@ contract T1BasicSwapE2E is BaseTest {
 
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
-
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
+        bytes memory innerMessage = abi.encode(false, orderIds, emptyOrdersFillerData);
+        _handleRelayMessage(destination, 1, innerMessage, keccak256(innerMessage));
 
         uint256[] memory balancesAfterRefund = _balances(inputToken);
 
@@ -774,20 +777,57 @@ contract T1BasicSwapE2E is BaseTest {
         assertEq(balancesAfterRefund[balanceId[kakaroto]], balancesBeforeRefund[balanceId[kakaroto]] + amount);
     }
 
+    function test_fill_settle_failure_invalid_proof() public {
+        // open
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(originRouter), amount);
+        vm.recordLogs();
+        originRouter.open(order);
+        (bytes32 orderId, ResolvedCrossChainOrder memory resolvedOrder) = _getOrderIDFromLogs();
+        vm.stopPrank();
+
+        // fill
+        vm.startPrank(vegeta);
+        outputToken.approve(address(destinationRouter), amount);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        destinationRouter.fill(orderId, resolvedOrder.fillInstructions[0].originData, fillerData);
+
+        // settle
+        bytes32[] memory orderIds = new bytes32[](1);
+        orderIds[0] = orderId;
+        bytes[] memory ordersFillerData = new bytes[](1);
+        ordersFillerData[0] = fillerData;
+        destinationRouter.settle(orderIds);
+        vm.stopPrank();
+
+        bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
+
+        vm.recordLogs();
+        _handleRelayMessage(destination, 1, innerMessage, bytes32(0));
+        Vm.Log[] memory _logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < _logs.length; i++) {
+            Vm.Log memory _log = _logs[i];
+            if (_log.topics[0] == IT1Messenger.FailedRelayedMessage.selector) {
+                return;
+            }
+        }
+        revert("There was not a FailedRelayedMessage event");
+    }
+
     function _handleRelayMessage(
-        bytes32[] memory orderIds,
-        bytes[] memory ordersFillerData,
-        bool isSettle,
         uint32 _destination,
-        uint256 batchIndex
+        uint256 batchIndex,
+        bytes memory innerMessage,
+        bytes32 proofOfFill7683Root
     )
         internal
     {
         rollup.addProver(address(0));
         bytes memory batchHeader1 = BatchHeaders.generateBatchHeader(rollup);
         assertEq(rollup.isBatchFinalized(1), false);
-
-        bytes memory innerMessage = abi.encode(isSettle, orderIds, ordersFillerData);
 
         // hash 0xcca132db240c06c148d210ceda18701a38e863e5ab2ed4638b15b6c7b30a08ae
         uint256 nonce = 0;
@@ -804,7 +844,7 @@ contract T1BasicSwapE2E is BaseTest {
             "relayMessage(address,address,uint256,uint256,bytes)", from, to, msgValue, nonce, outerMessage
         );
 
-        rollup.setProofOfFill7683Root(batchIndex, keccak256(innerMessage));
+        rollup.setProofOfFill7683Root(batchIndex, proofOfFill7683Root);
 
         bytes32 withdrawRoot = keccak256(xDomainCalldata);
         vm.startPrank(address(0));

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -296,7 +296,7 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         uint256[] memory balancesBeforeSettle = _balances(inputToken);
-        _handleRelayMessage(orderIds, ordersFillerData, true, origin, 1);
+        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
 
         uint256[] memory balancesAfterSettle = _balances(inputToken);
 
@@ -583,7 +583,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
 
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, origin, 1);
+        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
 
         uint256[] memory balancesAfterRefund = _balances(inputToken);
 
@@ -789,19 +789,22 @@ contract T1BasicSwapE2E is BaseTest {
 
         bytes memory innerMessage = abi.encode(isSettle, orderIds, ordersFillerData);
 
-        bytes memory outerMessage = abi.encodeWithSelector(
-            T1ERC7683.handle.selector, _destination, destinationRouterB32, batchIndex, bytes32(0), innerMessage
-        );
-
         // hash 0xcca132db240c06c148d210ceda18701a38e863e5ab2ed4638b15b6c7b30a08ae
         uint256 nonce = 0;
         uint256 msgValue = 0;
         address from = address(destinationRouter);
         address to = address(originRouter);
+        bytes memory proof = hex"";
+
+        bytes memory outerMessage = abi.encodeWithSelector(
+            T1ERC7683.handle.selector, _destination, destinationRouterB32, batchIndex, proof, nonce, innerMessage
+        );
 
         bytes memory xDomainCalldata = abi.encodeWithSignature(
             "relayMessage(address,address,uint256,uint256,bytes)", from, to, msgValue, nonce, outerMessage
         );
+
+        rollup.setProofOfFill7683Root(batchIndex, keccak256(innerMessage));
 
         bytes32 withdrawRoot = keccak256(xDomainCalldata);
         vm.startPrank(address(0));
@@ -813,7 +816,6 @@ contract T1BasicSwapE2E is BaseTest {
         bytes32 withdrawRootBatch1 = rollup.withdrawRoots(1);
         assertEq(withdrawRoot, withdrawRootBatch1, "withdraw root");
 
-        bytes memory proof = hex"";
         IL1T1Messenger.L2MessageProof memory messageProof =
             IL1T1Messenger.L2MessageProof({ batchIndex: 1, merkleProof: proof });
         l1t1Messenger.relayMessageWithProof(from, to, msgValue, nonce, outerMessage, messageProof);

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -806,7 +806,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes memory innerMessage = abi.encode(true, orderIds, ordersFillerData);
 
         vm.recordLogs();
-        _handleRelayMessage(destination, 1, innerMessage, bytes32(0));
+        _handleRelayMessage(destination, 1, innerMessage, bytes32(0)); //bad intent filled proof
         Vm.Log[] memory _logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < _logs.length; i++) {
             Vm.Log memory _log = _logs[i];
@@ -821,7 +821,7 @@ contract T1BasicSwapE2E is BaseTest {
         uint32 _destination,
         uint256 batchIndex,
         bytes memory innerMessage,
-        bytes32 proofOfFill7683Root
+        bytes32 intentFilledMerkleProof
     )
         internal
     {
@@ -837,14 +837,14 @@ contract T1BasicSwapE2E is BaseTest {
         bytes memory proof = hex"";
 
         bytes memory outerMessage = abi.encodeWithSelector(
-            T1ERC7683.handle.selector, _destination, destinationRouterB32, batchIndex, proof, nonce, innerMessage
+            T1ERC7683.handle.selector, _destination, destinationRouterB32, batchIndex, proof, 1, innerMessage
         );
 
         bytes memory xDomainCalldata = abi.encodeWithSignature(
             "relayMessage(address,address,uint256,uint256,bytes)", from, to, msgValue, nonce, outerMessage
         );
 
-        rollup.setProofOfFill7683Root(batchIndex, proofOfFill7683Root);
+        rollup.setIntentFilledMerkleProof(batchIndex, intentFilledMerkleProof);
 
         bytes32 withdrawRoot = keccak256(xDomainCalldata);
         vm.startPrank(address(0));

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -705,7 +705,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes memory innerMessage = abi.encode(isSettle, orderIds, ordersFillerData);
 
         bytes memory outerMessage =
-            abi.encodeWithSelector(T1ERC7683.handle.selector, destination, destinationRouterB32, innerMessage);
+            abi.encodeWithSelector(T1ERC7683.handle.selector, destination, destinationRouterB32, 1, bytes32(0), innerMessage);
 
         // hash 0xcca132db240c06c148d210ceda18701a38e863e5ab2ed4638b15b6c7b30a08ae
         uint256 nonce = 0;

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { Test, Vm } from "forge-std/Test.sol";
+
 import {
     TransparentUpgradeableProxy,
     ITransparentUpgradeableProxy
@@ -21,6 +23,7 @@ import { L1MessageQueue } from "../../L1/rollup/L1MessageQueue.sol";
 import { L2MessageQueue } from "../../L2/predeploys/L2MessageQueue.sol";
 import { L1T1Messenger } from "../../L1/L1T1Messenger.sol";
 import { IL1T1Messenger } from "../../L1/IL1T1Messenger.sol";
+import { IT1Messenger } from "../../libraries/IT1Messenger.sol";
 import { L2T1Messenger } from "../../L2/L2T1Messenger.sol";
 import { T1ChainMockBlob } from "../../mocks/T1ChainMockBlob.sol";
 import { MockRollupVerifier } from "../mocks/MockRollupVerifier.sol";
@@ -293,7 +296,7 @@ contract T1BasicSwapE2E is BaseTest {
         vm.stopPrank();
 
         uint256[] memory balancesBeforeSettle = _balances(inputToken);
-        _handleRelayMessage(orderIds, ordersFillerData, true);
+        _handleRelayMessage(orderIds, ordersFillerData, true, origin, 1);
 
         uint256[] memory balancesAfterSettle = _balances(inputToken);
 
@@ -308,6 +311,45 @@ contract T1BasicSwapE2E is BaseTest {
             balancesBeforeSettle[balanceId[address(originRouter)]] - amount,
             "originRouter balance after fill"
         );
+    }
+
+    function test_fill_settle_failure() public {
+        // open
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(originRouter), amount);
+        vm.recordLogs();
+        originRouter.open(order);
+        (bytes32 orderId, ResolvedCrossChainOrder memory resolvedOrder) = _getOrderIDFromLogs();
+        vm.stopPrank();
+
+        // fill
+        vm.startPrank(vegeta);
+        outputToken.approve(address(destinationRouter), amount);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        destinationRouter.fill(orderId, resolvedOrder.fillInstructions[0].originData, fillerData);
+
+        // settle
+        bytes32[] memory orderIds = new bytes32[](1);
+        orderIds[0] = orderId;
+        bytes[] memory ordersFillerData = new bytes[](1);
+        ordersFillerData[0] = fillerData;
+        destinationRouter.settle(orderIds);
+        vm.stopPrank();
+
+        vm.recordLogs();
+        // wrongly set origin instead of destination
+        _handleRelayMessage(orderIds, ordersFillerData, true, origin, 1);
+        Vm.Log[] memory _logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < _logs.length; i++) {
+            Vm.Log memory _log = _logs[i];
+            if (_log.topics[0] == IT1Messenger.FailedRelayedMessage.selector) {
+                return;
+            }
+        }
+        revert("There was not a FailedRelayedMessage event");
     }
 
     function test_native_open_fill_settle() public {
@@ -381,7 +423,7 @@ contract T1BasicSwapE2E is BaseTest {
 
         uint256[] memory balancesBeforeSettle = _balances();
 
-        _handleRelayMessage(orderIds, ordersFillerData, true);
+        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
 
         uint256[] memory balancesAfterSettle = _balances();
 
@@ -475,7 +517,7 @@ contract T1BasicSwapE2E is BaseTest {
 
         uint256[] memory balancesBeforeSettle = _balances(inputToken);
 
-        _handleRelayMessage(orderIds, ordersFillerData, true);
+        _handleRelayMessage(orderIds, ordersFillerData, true, destination, 1);
 
         uint256[] memory balancesAfterSettle = _balances(inputToken);
 
@@ -541,7 +583,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
 
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false);
+        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, origin, 1);
 
         uint256[] memory balancesAfterRefund = _balances(inputToken);
 
@@ -551,6 +593,41 @@ contract T1BasicSwapE2E is BaseTest {
             balancesBeforeRefund[balanceId[address(originRouter)]] - amount
         );
         assertEq(balancesAfterRefund[balanceId[kakaroto]], balancesBeforeRefund[balanceId[kakaroto]] + amount);
+    }
+
+    function test_refund_failure() public {
+        // open
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(originRouter), amount);
+        vm.recordLogs();
+        originRouter.open(order);
+        (bytes32 orderId,) = _getOrderIDFromLogs();
+
+        // refund
+        vm.warp(orderData.fillDeadline + 1);
+        bytes32[] memory orderIds = new bytes32[](1);
+        orderIds[0] = orderId;
+        OnchainCrossChainOrder[] memory orders = new OnchainCrossChainOrder[](1);
+        orders[0] = order;
+        destinationRouter.refund(orders);
+        vm.stopPrank();
+        bytes[] memory emptyOrdersFillerData = new bytes[](1);
+        emptyOrdersFillerData[0] = hex"";
+
+        vm.recordLogs();
+        // wrongly set origin instead of destination
+        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, origin, 1);
+        Vm.Log[] memory _logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < _logs.length; i++) {
+            Vm.Log memory _log = _logs[i];
+            if (_log.topics[0] == IT1Messenger.FailedRelayedMessage.selector) {
+                return;
+            }
+        }
+        revert("There was not a FailedRelayedMessage event");
     }
 
     function test_native_open_refund() public {
@@ -608,7 +685,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
 
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false);
+        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
 
         uint256[] memory balancesAfterRefund = _balances();
 
@@ -685,7 +762,7 @@ contract T1BasicSwapE2E is BaseTest {
         bytes[] memory emptyOrdersFillerData = new bytes[](1);
         emptyOrdersFillerData[0] = hex"";
 
-        _handleRelayMessage(orderIds, emptyOrdersFillerData, false);
+        _handleRelayMessage(orderIds, emptyOrdersFillerData, false, destination, 1);
 
         uint256[] memory balancesAfterRefund = _balances(inputToken);
 
@@ -697,15 +774,24 @@ contract T1BasicSwapE2E is BaseTest {
         assertEq(balancesAfterRefund[balanceId[kakaroto]], balancesBeforeRefund[balanceId[kakaroto]] + amount);
     }
 
-    function _handleRelayMessage(bytes32[] memory orderIds, bytes[] memory ordersFillerData, bool isSettle) internal {
+    function _handleRelayMessage(
+        bytes32[] memory orderIds,
+        bytes[] memory ordersFillerData,
+        bool isSettle,
+        uint32 _destination,
+        uint256 batchIndex
+    )
+        internal
+    {
         rollup.addProver(address(0));
         bytes memory batchHeader1 = BatchHeaders.generateBatchHeader(rollup);
         assertEq(rollup.isBatchFinalized(1), false);
 
         bytes memory innerMessage = abi.encode(isSettle, orderIds, ordersFillerData);
 
-        bytes memory outerMessage =
-            abi.encodeWithSelector(T1ERC7683.handle.selector, destination, destinationRouterB32, 1, bytes32(0), innerMessage);
+        bytes memory outerMessage = abi.encodeWithSelector(
+            T1ERC7683.handle.selector, _destination, destinationRouterB32, batchIndex, bytes32(0), innerMessage
+        );
 
         // hash 0xcca132db240c06c148d210ceda18701a38e863e5ab2ed4638b15b6c7b30a08ae
         uint256 nonce = 0;

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { Test, Vm } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Test.sol";
 
 import {
     TransparentUpgradeableProxy,

--- a/contracts/src/test/L1GatewayRouter.t.sol
+++ b/contracts/src/test/L1GatewayRouter.t.sol
@@ -121,7 +121,7 @@ contract L1GatewayRouterTest is L1GatewayTestBase, DeployPermit2, PermitSignatur
         router.setMM(address(this));
     }
 
-    function testOwnership() public {
+    function testOwnership() public view {
         assertEq(address(this), router.owner());
     }
 

--- a/contracts/src/test/L1MessageQueueWithGasPriceOracle.t.sol
+++ b/contracts/src/test/L1MessageQueueWithGasPriceOracle.t.sol
@@ -92,7 +92,7 @@ contract L1MessageQueueWithGasPriceOracleTest is T1TestBase {
         assertEq(queue.estimateCrossDomainMessageFee(gasLimit), baseFee * gasLimit);
     }
 
-    function testCalculateIntrinsicGasFee(bytes memory data) external {
+    function testCalculateIntrinsicGasFee(bytes memory data) external view {
         assertEq(queue.calculateIntrinsicGasFee(data), 21_000 + data.length * 16);
     }
 }

--- a/contracts/src/test/L1StandardERC20Gateway.t.sol
+++ b/contracts/src/test/L1StandardERC20Gateway.t.sol
@@ -111,7 +111,7 @@ contract L1StandardERC20GatewayTest is L1GatewayTestBase, DeployPermit2 {
         gateway.initialize();
     }
 
-    function testGetL2ERC20Address(address l1Address) public {
+    function testGetL2ERC20Address(address l1Address) public view {
         assertEq(
             gateway.getL2ERC20Address(l1Address), factory.computeL2TokenAddress(address(counterpartGateway), l1Address)
         );

--- a/contracts/src/test/L2GatewayRouter.t.sol
+++ b/contracts/src/test/L2GatewayRouter.t.sol
@@ -94,7 +94,7 @@ contract L2GatewayRouterTest is L2GatewayTestBase {
         vm.stopPrank();
     }
 
-    function testOwnership() public {
+    function testOwnership() public view {
         assertEq(address(this), router.owner());
     }
 

--- a/contracts/src/test/L2MessageQueue.t.sol
+++ b/contracts/src/test/L2MessageQueue.t.sol
@@ -14,7 +14,7 @@ contract L2MessageQueueTest is Test {
         queue.initialize(address(this));
     }
 
-    function testConstructor() external {
+    function testConstructor() external view {
         assertEq(queue.messenger(), address(this));
         assertEq(queue.nextMessageIndex(), 0);
     }

--- a/contracts/src/test/L2StandardERC20Gateway.t.sol
+++ b/contracts/src/test/L2StandardERC20Gateway.t.sol
@@ -104,7 +104,7 @@ contract L2StandardERC20GatewayTest is L2GatewayTestBase {
         gateway.initialize();
     }
 
-    function testGetL2ERC20Address(address l1Address) public {
+    function testGetL2ERC20Address(address l1Address) public view {
         assertEq(gateway.getL2ERC20Address(l1Address), factory.computeL2TokenAddress(address(gateway), l1Address));
     }
 

--- a/contracts/src/test/T1Chain.t.sol
+++ b/contracts/src/test/T1Chain.t.sol
@@ -1652,7 +1652,7 @@ contract T1ChainTest is Test {
      *      `"\x19Ethereum Signed Message:\n32"` prefix to match on-chain logic.
      *      This matches what T1Chain does internally with `toEthSignedMessageHash`.
      */
-    function _signWithdrawRoot(uint256 privKey, bytes32 root) internal returns (bytes memory sig) {
+    function _signWithdrawRoot(uint256 privKey, bytes32 root) internal pure returns (bytes memory sig) {
         // 1) Reproduce the prefixing: keccak256("\x19Ethereum Signed Message:\n32", root)
         bytes32 ethSignedMsg = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", root));
 

--- a/contracts/src/test/T1Chain.t.sol
+++ b/contracts/src/test/T1Chain.t.sol
@@ -1702,17 +1702,17 @@ contract T1ChainTest is Test {
         // Sign with VALID_SIGNER_KEY to produce a valid signature
         bytes memory withdrawSig = _signWithdrawRoot(VALID_SIGNER_KEY, withdrawRoot);
 
-        bytes32 proofOfFillRoot = keccak256(abi.encode("some proofOfFillRoot"));
+        bytes32 intentFilledMerkleProof = keccak256(abi.encode("some intentFilledMerkleProof"));
         // Sign with VALID_SIGNER_KEY to produce a valid signature
-        bytes memory proofOfFillSig = _signWithdrawRoot(VALID_SIGNER_KEY, proofOfFillRoot);
+        bytes memory intentFilledSig = _signWithdrawRoot(VALID_SIGNER_KEY, intentFilledMerkleProof);
 
         // Expect it to succeed
         uint256 batchIndex = 1;
-        rollup.finalizeBatchWithProof(batchIndex, withdrawRoot, withdrawSig, proofOfFillRoot, proofOfFillSig);
+        rollup.finalizeBatchWithProof(batchIndex, withdrawRoot, withdrawSig, intentFilledMerkleProof, intentFilledSig);
 
         assertEq(rollup.lastFinalizedBatchIndex(), batchIndex);
         assertEq(rollup.withdrawRoots(batchIndex), withdrawRoot);
-        assertEq(rollup.proofOfFill7683Roots(batchIndex), proofOfFillRoot);
+        assertEq(rollup.intentFilledMerkleProofs(batchIndex), intentFilledMerkleProof);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Relay 7683 settlements from target chain including an intent filled Merkle proof.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Currently, `T1Chain` L1 contract is holding a `proofOfFill7683Roots` which maps a finalised batch to a root of `ProofOfFill7683` Trie valid for that particular batch. 7683 handle interface has been modified so that client contracts can submit a proof of fill Merkle inclusion root.  It then validate the proofs using a specific `orderId`, generate a Merkle Root based on these validations and compare it with Proof of Fill Root saved in `T1Chain`.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

`forge test --match-contract T1BasicSwapE2E`

## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] This change includes any required documentation updates.
-   [x] This change includes any required test coverage.
-   [ ] The version has been bumped according to our internal semantic versioning rules˚¬˚

˚¬˚ Semantic versioning rules:
* Patch (i.e. 0.0.1) bumped if this change requires a redeployment/upgrade of contracts
* Minor (i.e. 0.1.0) bumped if this change requires a new network deployment/hard fork
* Major (i.e. 1.0.0) bumped if this change means we have achieved escape velocity