### PR TITLE
fix: deposit script accounts for decimal change

### DIFF
--- a/contracts/script/test/DepositUsdtFromL1ToL2.s.sol
+++ b/contracts/script/test/DepositUsdtFromL1ToL2.s.sol
@@ -21,9 +21,9 @@ contract DepositUsdtFromL1ToL2 is Script {
 
         uint256 gasLimit = 1_000_000;
 
-        T1StandardERC20(L1_USDT_ADDR).approve(L1_GATEWAY_ROUTER_PROXY_ADDR, 1000 ether);
-
-        IL1GatewayRouter(L1_GATEWAY_ROUTER_PROXY_ADDR).depositERC20(L1_USDT_ADDR, 1000 ether, gasLimit);
+       uint256 depositAmount = 1_000 * 1e6;
+        T1StandardERC20(L1_USDT_ADDR).approve(L1_GATEWAY_ROUTER_PROXY_ADDR, depositAmount);
+        IL1GatewayRouter(L1_GATEWAY_ROUTER_PROXY_ADDR).depositERC20(L1_USDT_ADDR, depositAmount, gasLimit);
 
         address l2usdtAddress = IL1GatewayRouter(L1_GATEWAY_ROUTER_PROXY_ADDR).getL2ERC20Address(L1_USDT_ADDR);
         logAddress("L2_USDT_ADDR", l2usdtAddress);

--- a/contracts/script/test/DepositUsdtFromL1ToL2.s.sol
+++ b/contracts/script/test/DepositUsdtFromL1ToL2.s.sol
@@ -21,7 +21,7 @@ contract DepositUsdtFromL1ToL2 is Script {
 
         uint256 gasLimit = 1_000_000;
 
-       uint256 depositAmount = 1_000 * 1e6;
+        uint256 depositAmount = 1000 * 1e6;
         T1StandardERC20(L1_USDT_ADDR).approve(L1_GATEWAY_ROUTER_PROXY_ADDR, depositAmount);
         IL1GatewayRouter(L1_GATEWAY_ROUTER_PROXY_ADDR).depositERC20(L1_USDT_ADDR, depositAmount, gasLimit);
 


### PR DESCRIPTION
The deposit script didn't account for decimal places change in USDT. Instead of bridging 1k it was trying to bridge 1 trillion.

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [ ] This change includes any required documentation updates.
-   [ ] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [ ] This change includes any required test coverage.
-   [ ] The version has been bumped according to our internal semantic versioning rules˚¬˚

˚¬˚ Semantic versioning rules:
* Patch (i.e. 0.0.1) bumped if this change requires a redeployment/upgrade of contracts
* Minor (i.e. 0.1.0) bumped if this change requires a new network deployment/hard fork
* Major (i.e. 1.0.0) bumped if this change means we have achieved escape velocity