### PR TITLE
Refactor: handle xCR callback failure

### DIFF
--- a/contracts/src/7683/T1ERC7683Pull.sol
+++ b/contracts/src/7683/T1ERC7683Pull.sol
@@ -116,6 +116,7 @@ contract T1ERC7683Pull is BasicSwap7683, OwnableUpgradeable, IT1XChainReaderCall
         bytes calldata result
     )
         external
+        override
         onlyXChainRead
     {
         bytes32 orderId = readRequestToOrderId[requestId];

--- a/contracts/src/libraries/xChain/BaseT1XChainReader.sol
+++ b/contracts/src/libraries/xChain/BaseT1XChainReader.sol
@@ -59,8 +59,8 @@ abstract contract BaseT1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgra
 
     // ============ State Variables ============
 
-    IT1Messenger public immutable messenger;
     /// @notice The T1 messenger contract used for cross-chain communication
+    IT1Messenger public immutable messenger;
 
     /// @notice The T1 prover
     address public immutable prover;

--- a/contracts/src/libraries/xChain/BaseT1XChainReader.sol
+++ b/contracts/src/libraries/xChain/BaseT1XChainReader.sol
@@ -213,6 +213,5 @@ abstract contract BaseT1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgra
                 emit ReadFailed(requestId, result, reason);
             }
         }
-
     }
 }

--- a/contracts/src/libraries/xChain/BaseT1XChainReader.sol
+++ b/contracts/src/libraries/xChain/BaseT1XChainReader.sol
@@ -35,11 +35,27 @@ abstract contract BaseT1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgra
     );
 
     /**
-     * @notice Emitted when a cross-chain read response is received
+     * @notice Emitted when a cross-chain read response succeeds
      * @param requestId Unique identifier for the original request
      * @param result The result data from the read operation
      */
-    event ReadResult(bytes32 indexed requestId, bytes result);
+    event ReadSucceeded(bytes32 indexed requestId, bytes result);
+
+    /**
+     * @notice Emitted when a cross-chain read response fails with bytes revert
+     * @param requestId Unique identifier for the original request
+     * @param result The result data from the read operation
+     * @param reason The reason the call failed
+     */
+    event ReadFailed(bytes32 indexed requestId, bytes result, bytes reason);
+
+    /**
+     * @notice Emitted when a cross-chain read response fails with string revert
+     * @param requestId Unique identifier for the original request
+     * @param result The result data from the read operation
+     * @param reason The reason the call failed
+     */
+    event ReadFailed(bytes32 indexed requestId, bytes result, string reason);
 
     // ============ State Variables ============
 
@@ -189,10 +205,14 @@ abstract contract BaseT1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgra
         // If there's a valid callback, forward the result
         if (callback != address(0)) {
             delete callbacks[requestId];
-
-            IT1XChainReaderCallback(callback).onT1XChainReaderResult(_originDomain, _sender, requestId, result);
+            try IT1XChainReaderCallback(callback).onT1XChainReaderResult(_originDomain, _sender, requestId, result) {
+                emit ReadSucceeded(requestId, result);
+            } catch Error(string memory reason) {
+                emit ReadFailed(requestId, result, reason);
+            } catch (bytes memory reason) {
+                emit ReadFailed(requestId, result, reason);
+            }
         }
 
-        emit ReadResult(requestId, result);
     }
 }

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -13,181 +13,179 @@ import { T1BasicSwapE2E } from "./T1BasicSwapE2E.t.sol";
 import { T1ERC7683Pull } from "../../7683/T1ERC7683Pull.sol";
 
 contract MockCallbackContract is IT1XChainReaderCallback {
-  function onT1XChainReaderResult(
-    uint32 _originDomain,
-    bytes32 _sender,
-    bytes32 requestId,
-    bytes calldata result
-  ) external override {
-    require(false, "revert!");
-  }
+    function onT1XChainReaderResult(
+        uint32 _originDomain,
+        bytes32 _sender,
+        bytes32 requestId,
+        bytes calldata result
+    )
+        external
+        override
+    {
+        require(false, "revert!");
+    }
 }
 
 contract T1XChainReaderTest is T1BasicSwapE2E {
-  using TypeCasts for address;
+    using TypeCasts for address;
 
-  T1XChainReader internal originReader;
-  T1XChainReader internal destinationReader;
-  T1ERC7683Pull internal L1T17683Pull;
-  T1ERC7683Pull internal L2T17683Pull;
-  MockCallbackContract internal mockCallbackContract;
+    T1XChainReader internal originReader;
+    T1XChainReader internal destinationReader;
+    T1ERC7683Pull internal L1T17683Pull;
+    T1ERC7683Pull internal L2T17683Pull;
+    MockCallbackContract internal mockCallbackContract;
 
-  function setUp() public virtual override {
-    super.setUp();
+    function setUp() public virtual override {
+        super.setUp();
 
-    // Deploy T1XChainReader on both chains
-    originReader = T1XChainReader(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(originReader)),
-      address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
-    );
+        // Deploy T1XChainReader on both chains
+        originReader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(originReader)),
+            address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
+        );
 
-    destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(destinationReader)),
-      address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
-    );
+        destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(destinationReader)),
+            address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
+        );
 
-    L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-    L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(L1T17683Pull)),
-      address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
-    );
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(L2T17683Pull)),
-      address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
-    );
-    L1T17683Pull.initialize(address(L2T17683Pull));
-    L2T17683Pull.initialize(address(L1T17683Pull));
-    mockCallbackContract = new MockCallbackContract();
-  }
-
-  // 1. user opens intent on source chain
-  // 2. solver fills intent on destination chain
-  // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
-  // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
-  // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
-  // onT1XChainReaderResult on callback address
-  // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
-  function test_ERC7683PullSettlementFlow() public {
-    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
-    {
-      // Construct the read request calldata
-      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-      uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-      uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-      assertEq(
-        balanceSolverBeforeSettle + amount,
-        balanceSolverAfterSettle,
-        "vegeta balance increased by input amount"
-      );
+        L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+        L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(L1T17683Pull)),
+            address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
+        );
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(L2T17683Pull)),
+            address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
+        );
+        L1T17683Pull.initialize(address(L2T17683Pull));
+        L2T17683Pull.initialize(address(L1T17683Pull));
+        mockCallbackContract = new MockCallbackContract();
     }
 
-    // Verify the final state on L1
-    assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
-  }
+    // 1. user opens intent on source chain
+    // 2. solver fills intent on destination chain
+    // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
+    // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
+    // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
+    // onT1XChainReaderResult on callback address
+    // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
+    function test_ERC7683PullSettlementFlow() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-  function test_handleSucceededCallback() public {
-    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+        {
+            // Construct the read request calldata
+            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+            uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+            uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
 
-    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
-    {
-      // Construct the read request calldata
-      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+            assertEq(
+                balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+            );
+        }
 
-      vm.expectEmit(true, true, true, true);
-      emit BaseT1XChainReader.ReadSucceeded(requestId, orderStatus);
-      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+        // Verify the final state on L1
+        assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
     }
-  }
 
-  function test_handleGenericFailedCallback() public {
-    (, , bytes32 requestId) = _openAndFillOrder();
+    function test_handleSucceededCallback() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-    // 4. Attempt to process the read request on L2
-    {
-      // Construct bad read request calldata
-      bytes memory orderStatus = hex"11";
-      bytes memory revertReason = hex"";
-      vm.expectEmit(true, true, true, true);
-      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+        // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+        {
+            // Construct the read request calldata
+            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+
+            vm.expectEmit(true, true, true, true);
+            emit BaseT1XChainReader.ReadSucceeded(requestId, orderStatus);
+            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+        }
     }
-  }
 
-  function test_handleCustomFailedCallback() public {
-    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-    bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
-    // 4. Attempt to process the read request on L2
-    {
-      // Construct bad read request calldata
-      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-      bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
-      vm.expectEmit(true, true, true, true);
-      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-      originReader.handle(destination, badSender, requestId, orderStatus);
+    function test_handleGenericFailedCallback() public {
+        (,, bytes32 requestId) = _openAndFillOrder();
+
+        // 4. Attempt to process the read request on L2
+        {
+            // Construct bad read request calldata
+            bytes memory orderStatus = hex"11";
+            bytes memory revertReason = hex"";
+            vm.expectEmit(true, true, true, true);
+            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+        }
     }
-  }
 
-  function test_handleRevertStringFailedCallback() public {
-    BaseT1XChainReader.ReadRequest memory readRequest = BaseT1XChainReader.ReadRequest({
+    function test_handleCustomFailedCallback() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
+        // 4. Attempt to process the read request on L2
+        {
+            // Construct bad read request calldata
+            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+            bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
+            vm.expectEmit(true, true, true, true);
+            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+            originReader.handle(destination, badSender, requestId, orderStatus);
+        }
+    }
+
+    function test_handleRevertStringFailedCallback() public {
+        BaseT1XChainReader.ReadRequest memory readRequest = BaseT1XChainReader.ReadRequest({
             destinationDomain: uint32(0),
             targetContract: address(0),
             minBlock: 0,
             callData: hex"",
             callback: address(mockCallbackContract)
-    });
-    bytes32 requestId = originReader.requestRead(readRequest);
+        });
+        bytes32 requestId = originReader.requestRead(readRequest);
 
-    string memory revertReason = "revert!";
-    vm.expectEmit(true, true, true, true);
-    emit BaseT1XChainReader.ReadFailed(requestId, hex"", revertReason);
-    originReader.handle(destination, bytes32(0), requestId, hex"");
-  }
+        string memory revertReason = "revert!";
+        vm.expectEmit(true, true, true, true);
+        emit BaseT1XChainReader.ReadFailed(requestId, hex"", revertReason);
+        originReader.handle(destination, bytes32(0), requestId, hex"");
+    }
 
-  function test_onlyProver_revert() public {
-    bytes32 requestId = hex"";
-    bytes memory orderStatus = hex"";
+    function test_onlyProver_revert() public {
+        bytes32 requestId = hex"";
+        bytes memory orderStatus = hex"";
 
-    vm.prank(address(0xbeef));
-    vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
-    originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-  }
+        vm.prank(address(0xbeef));
+        vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
+        originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+    }
 
-  function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
-    OrderData memory orderData = _prepareOrderData();
-    OnchainCrossChainOrder memory order = _prepareOnchainOrder(
-      OrderEncoder.encode(orderData),
-      orderData.fillDeadline,
-      OrderEncoder.orderDataType()
-    );
+    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
 
-    vm.startPrank(kakaroto);
-    inputToken.approve(address(L1T17683Pull), amount);
-    vm.recordLogs();
-    L1T17683Pull.open(order);
-    vm.stopPrank();
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(L1T17683Pull), amount);
+        vm.recordLogs();
+        L1T17683Pull.open(order);
+        vm.stopPrank();
 
-    (bytes32 orderId_, ) = _getOrderIDFromLogs();
-    assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
 
-    vm.startPrank(vegeta);
-    outputToken.approve(address(L2T17683Pull), amount);
-    bytes memory originData = OrderEncoder.encode(orderData);
-    bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
-    L2T17683Pull.fill(orderId_, originData, fillerData);
-    assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
-    vm.stopPrank();
+        vm.startPrank(vegeta);
+        outputToken.approve(address(L2T17683Pull), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        L2T17683Pull.fill(orderId_, originData, fillerData);
+        assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
+        vm.stopPrank();
 
-    vm.startPrank(vegeta);
-    bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
-    vm.stopPrank();
+        vm.startPrank(vegeta);
+        bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
+        vm.stopPrank();
 
-    return (orderData, orderId_, requestId_);
-  }
+        return (orderData, orderId_, requestId_);
+    }
 }

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -12,102 +12,138 @@ import { T1BasicSwapE2E } from "./T1BasicSwapE2E.t.sol";
 import { T1ERC7683Pull } from "../../7683/T1ERC7683Pull.sol";
 
 contract T1XChainReaderTest is T1BasicSwapE2E {
-    using TypeCasts for address;
+  using TypeCasts for address;
 
-    T1XChainReader internal originReader;
-    T1XChainReader internal destinationReader;
-    T1ERC7683Pull internal L1T17683Pull;
-    T1ERC7683Pull internal L2T17683Pull;
+  T1XChainReader internal originReader;
+  T1XChainReader internal destinationReader;
+  T1ERC7683Pull internal L1T17683Pull;
+  T1ERC7683Pull internal L2T17683Pull;
 
-    function setUp() public virtual override {
-        super.setUp();
+  function setUp() public virtual override {
+    super.setUp();
 
-        // Deploy T1XChainReader on both chains
-        originReader = T1XChainReader(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(originReader)),
-            address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
-        );
+    // Deploy T1XChainReader on both chains
+    originReader = T1XChainReader(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(originReader)),
+      address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
+    );
 
-        destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(destinationReader)),
-            address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
-        );
+    destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(destinationReader)),
+      address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
+    );
 
-        L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-        L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(L1T17683Pull)),
-            address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
-        );
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(L2T17683Pull)),
-            address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
-        );
-        L1T17683Pull.initialize(address(L2T17683Pull));
-        L2T17683Pull.initialize(address(L1T17683Pull));
+    L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+    L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(L1T17683Pull)),
+      address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
+    );
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(L2T17683Pull)),
+      address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
+    );
+    L1T17683Pull.initialize(address(L2T17683Pull));
+    L2T17683Pull.initialize(address(L1T17683Pull));
+  }
+
+  // 1. user opens intent on source chain
+  // 2. solver fills intent on destination chain
+  // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
+  // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
+  // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
+  // onT1XChainReaderResult on callback address
+  // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
+  function test_ERC7683PullSettlementFlow() public {
+    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+    {
+      // Construct the read request calldata
+      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+      uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+      uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+      assertEq(
+        balanceSolverBeforeSettle + amount,
+        balanceSolverAfterSettle,
+        "vegeta balance increased by input amount"
+      );
     }
 
-    // 1. user opens intent on source chain
-    // 2. solver fills intent on destination chain
-    // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
-    // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
-    // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
-    // onT1XChainReaderResult on callback address
-    // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
-    function test_ERC7683PullSettlementFlow() public {
-        // 1. Setup: Open an order on L1 (origin chain)
-        OrderData memory orderData = _prepareOrderData();
-        OnchainCrossChainOrder memory order =
-            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+    // Verify the final state on L1
+    assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
+  }
 
-        vm.startPrank(kakaroto);
-        inputToken.approve(address(L1T17683Pull), amount);
-        vm.recordLogs();
-        L1T17683Pull.open(order);
-        vm.stopPrank();
+  function test_handleGenericFailedCallback() public {
+    (,, bytes32 requestId) = _openAndFillOrder();
 
-        (bytes32 orderId,) = _getOrderIDFromLogs();
-        assertEq(L1T17683Pull.orderStatus(orderId), _base7683.OPENED());
-
-        // 2. Fill the order on L2 (destination chain)
-        vm.startPrank(vegeta);
-        outputToken.approve(address(L2T17683Pull), amount);
-        bytes memory originData = OrderEncoder.encode(orderData);
-        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
-        L2T17683Pull.fill(orderId, originData, fillerData);
-        assertEq(L2T17683Pull.orderStatus(orderId), L2T17683Pull.FILLED());
-        vm.stopPrank();
-
-        // 3. Filler initiates settlement verification from L1
-        vm.startPrank(vegeta);
-        bytes32 requestId = L1T17683Pull.verifySettlement(destination, orderId);
-        vm.stopPrank();
-
-        // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
-        {
-            // Construct the read request calldata
-            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-            uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-            uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-            assertEq(
-                balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
-            );
-        }
-
-        // Verify the final state on L1
-        assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
+    // 4. Attempt to process the read request on L2
+    {
+      // Construct bad read request calldata
+      bytes memory orderStatus = hex"11";
+      bytes memory revertReason = hex"";
+      vm.expectEmit(true, true, true, true);
+      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
     }
+  }
 
-    function test_onlyProver_revert() public {
-        bytes32 requestId = hex"";
-        bytes memory orderStatus = hex"";
-
-        vm.prank(address(0xbeef));
-        vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
-        originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+  function test_handleCustomFailedCallback() public {
+    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+    bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
+    // 4. Attempt to process the read request on L2
+    {
+      // Construct bad read request calldata
+      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+      bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
+      vm.expectEmit(true, true, true, true);
+      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+      originReader.handle(destination, badSender, requestId, orderStatus);
     }
+  }
+
+  function test_onlyProver_revert() public {
+    bytes32 requestId = hex"";
+    bytes memory orderStatus = hex"";
+
+    vm.prank(address(0xbeef));
+    vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
+    originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+  }
+
+  function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+    OrderData memory orderData = _prepareOrderData();
+    OnchainCrossChainOrder memory order = _prepareOnchainOrder(
+      OrderEncoder.encode(orderData),
+      orderData.fillDeadline,
+      OrderEncoder.orderDataType()
+    );
+
+    vm.startPrank(kakaroto);
+    inputToken.approve(address(L1T17683Pull), amount);
+    vm.recordLogs();
+    L1T17683Pull.open(order);
+    vm.stopPrank();
+
+    (bytes32 orderId_, ) = _getOrderIDFromLogs();
+    assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
+
+    vm.startPrank(vegeta);
+    outputToken.approve(address(L2T17683Pull), amount);
+    bytes memory originData = OrderEncoder.encode(orderData);
+    bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+    L2T17683Pull.fill(orderId_, originData, fillerData);
+    assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
+    vm.stopPrank();
+
+    vm.startPrank(vegeta);
+    bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
+    vm.stopPrank();
+
+    return (orderData, orderId_, requestId_);
+  }
 }

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -12,138 +12,133 @@ import { T1BasicSwapE2E } from "./T1BasicSwapE2E.t.sol";
 import { T1ERC7683Pull } from "../../7683/T1ERC7683Pull.sol";
 
 contract T1XChainReaderTest is T1BasicSwapE2E {
-  using TypeCasts for address;
+    using TypeCasts for address;
 
-  T1XChainReader internal originReader;
-  T1XChainReader internal destinationReader;
-  T1ERC7683Pull internal L1T17683Pull;
-  T1ERC7683Pull internal L2T17683Pull;
+    T1XChainReader internal originReader;
+    T1XChainReader internal destinationReader;
+    T1ERC7683Pull internal L1T17683Pull;
+    T1ERC7683Pull internal L2T17683Pull;
 
-  function setUp() public virtual override {
-    super.setUp();
+    function setUp() public virtual override {
+        super.setUp();
 
-    // Deploy T1XChainReader on both chains
-    originReader = T1XChainReader(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(originReader)),
-      address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
-    );
+        // Deploy T1XChainReader on both chains
+        originReader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(originReader)),
+            address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
+        );
 
-    destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(destinationReader)),
-      address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
-    );
+        destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(destinationReader)),
+            address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
+        );
 
-    L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-    L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(L1T17683Pull)),
-      address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
-    );
-    admin.upgrade(
-      ITransparentUpgradeableProxy(address(L2T17683Pull)),
-      address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
-    );
-    L1T17683Pull.initialize(address(L2T17683Pull));
-    L2T17683Pull.initialize(address(L1T17683Pull));
-  }
-
-  // 1. user opens intent on source chain
-  // 2. solver fills intent on destination chain
-  // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
-  // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
-  // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
-  // onT1XChainReaderResult on callback address
-  // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
-  function test_ERC7683PullSettlementFlow() public {
-    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
-    {
-      // Construct the read request calldata
-      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-      uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-      uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-      assertEq(
-        balanceSolverBeforeSettle + amount,
-        balanceSolverAfterSettle,
-        "vegeta balance increased by input amount"
-      );
+        L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+        L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(L1T17683Pull)),
+            address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
+        );
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(L2T17683Pull)),
+            address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
+        );
+        L1T17683Pull.initialize(address(L2T17683Pull));
+        L2T17683Pull.initialize(address(L1T17683Pull));
     }
 
-    // Verify the final state on L1
-    assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
-  }
+    // 1. user opens intent on source chain
+    // 2. solver fills intent on destination chain
+    // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
+    // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
+    // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
+    // onT1XChainReaderResult on callback address
+    // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
+    function test_ERC7683PullSettlementFlow() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-  function test_handleGenericFailedCallback() public {
-    (,, bytes32 requestId) = _openAndFillOrder();
+        // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+        {
+            // Construct the read request calldata
+            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+            uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+            uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
 
-    // 4. Attempt to process the read request on L2
-    {
-      // Construct bad read request calldata
-      bytes memory orderStatus = hex"11";
-      bytes memory revertReason = hex"";
-      vm.expectEmit(true, true, true, true);
-      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+            assertEq(
+                balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+            );
+        }
+
+        // Verify the final state on L1
+        assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
     }
-  }
 
-  function test_handleCustomFailedCallback() public {
-    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-    bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
-    // 4. Attempt to process the read request on L2
-    {
-      // Construct bad read request calldata
-      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-      bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
-      vm.expectEmit(true, true, true, true);
-      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-      originReader.handle(destination, badSender, requestId, orderStatus);
+    function test_handleGenericFailedCallback() public {
+        (,, bytes32 requestId) = _openAndFillOrder();
+
+        // 4. Attempt to process the read request on L2
+        {
+            // Construct bad read request calldata
+            bytes memory orderStatus = hex"11";
+            bytes memory revertReason = hex"";
+            vm.expectEmit(true, true, true, true);
+            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+        }
     }
-  }
 
-  function test_onlyProver_revert() public {
-    bytes32 requestId = hex"";
-    bytes memory orderStatus = hex"";
+    function test_handleCustomFailedCallback() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
+        // 4. Attempt to process the read request on L2
+        {
+            // Construct bad read request calldata
+            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+            bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
+            vm.expectEmit(true, true, true, true);
+            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+            originReader.handle(destination, badSender, requestId, orderStatus);
+        }
+    }
 
-    vm.prank(address(0xbeef));
-    vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
-    originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-  }
+    function test_onlyProver_revert() public {
+        bytes32 requestId = hex"";
+        bytes memory orderStatus = hex"";
 
-  function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
-    OrderData memory orderData = _prepareOrderData();
-    OnchainCrossChainOrder memory order = _prepareOnchainOrder(
-      OrderEncoder.encode(orderData),
-      orderData.fillDeadline,
-      OrderEncoder.orderDataType()
-    );
+        vm.prank(address(0xbeef));
+        vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
+        originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+    }
 
-    vm.startPrank(kakaroto);
-    inputToken.approve(address(L1T17683Pull), amount);
-    vm.recordLogs();
-    L1T17683Pull.open(order);
-    vm.stopPrank();
+    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
 
-    (bytes32 orderId_, ) = _getOrderIDFromLogs();
-    assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(L1T17683Pull), amount);
+        vm.recordLogs();
+        L1T17683Pull.open(order);
+        vm.stopPrank();
 
-    vm.startPrank(vegeta);
-    outputToken.approve(address(L2T17683Pull), amount);
-    bytes memory originData = OrderEncoder.encode(orderData);
-    bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
-    L2T17683Pull.fill(orderId_, originData, fillerData);
-    assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
-    vm.stopPrank();
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
 
-    vm.startPrank(vegeta);
-    bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
-    vm.stopPrank();
+        vm.startPrank(vegeta);
+        outputToken.approve(address(L2T17683Pull), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        L2T17683Pull.fill(orderId_, originData, fillerData);
+        assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
+        vm.stopPrank();
 
-    return (orderData, orderId_, requestId_);
-  }
+        vm.startPrank(vegeta);
+        bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
+        vm.stopPrank();
+
+        return (orderData, orderId_, requestId_);
+    }
 }

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -8,137 +8,186 @@ import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
 
 import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
 import { BaseT1XChainReader } from "../../libraries/xChain/BaseT1XChainReader.sol";
+import { IT1XChainReaderCallback } from "../../libraries/xChain/IT1XChainReaderCallback.sol";
 import { T1BasicSwapE2E } from "./T1BasicSwapE2E.t.sol";
 import { T1ERC7683Pull } from "../../7683/T1ERC7683Pull.sol";
 
+contract MockCallbackContract is IT1XChainReaderCallback {
+  function onT1XChainReaderResult(
+    uint32 _originDomain,
+    bytes32 _sender,
+    bytes32 requestId,
+    bytes calldata result
+  ) external override {
+    require(false, "revert!");
+  }
+}
+
 contract T1XChainReaderTest is T1BasicSwapE2E {
-    using TypeCasts for address;
+  using TypeCasts for address;
 
-    T1XChainReader internal originReader;
-    T1XChainReader internal destinationReader;
-    T1ERC7683Pull internal L1T17683Pull;
-    T1ERC7683Pull internal L2T17683Pull;
+  T1XChainReader internal originReader;
+  T1XChainReader internal destinationReader;
+  T1ERC7683Pull internal L1T17683Pull;
+  T1ERC7683Pull internal L2T17683Pull;
+  MockCallbackContract internal mockCallbackContract;
 
-    function setUp() public virtual override {
-        super.setUp();
+  function setUp() public virtual override {
+    super.setUp();
 
-        // Deploy T1XChainReader on both chains
-        originReader = T1XChainReader(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(originReader)),
-            address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
-        );
+    // Deploy T1XChainReader on both chains
+    originReader = T1XChainReader(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(originReader)),
+      address(new T1XChainReader(address(l1t1Messenger), address(this), origin))
+    );
 
-        destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(destinationReader)),
-            address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
-        );
+    destinationReader = T1XChainReader(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(destinationReader)),
+      address(new T1XChainReader(address(l2t1Messenger), address(this), destination))
+    );
 
-        L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-        L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(L1T17683Pull)),
-            address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
-        );
-        admin.upgrade(
-            ITransparentUpgradeableProxy(address(L2T17683Pull)),
-            address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
-        );
-        L1T17683Pull.initialize(address(L2T17683Pull));
-        L2T17683Pull.initialize(address(L1T17683Pull));
+    L1T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+    L2T17683Pull = T1ERC7683Pull(payable(_deployProxy(address(0))));
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(L1T17683Pull)),
+      address(new T1ERC7683Pull(address(0), address(originReader), uint32(origin)))
+    );
+    admin.upgrade(
+      ITransparentUpgradeableProxy(address(L2T17683Pull)),
+      address(new T1ERC7683Pull(address(0), address(destinationReader), uint32(destination)))
+    );
+    L1T17683Pull.initialize(address(L2T17683Pull));
+    L2T17683Pull.initialize(address(L1T17683Pull));
+    mockCallbackContract = new MockCallbackContract();
+  }
+
+  // 1. user opens intent on source chain
+  // 2. solver fills intent on destination chain
+  // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
+  // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
+  // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
+  // onT1XChainReaderResult on callback address
+  // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
+  function test_ERC7683PullSettlementFlow() public {
+    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+    {
+      // Construct the read request calldata
+      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+      uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+      uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+      assertEq(
+        balanceSolverBeforeSettle + amount,
+        balanceSolverAfterSettle,
+        "vegeta balance increased by input amount"
+      );
     }
 
-    // 1. user opens intent on source chain
-    // 2. solver fills intent on destination chain
-    // 3a. solver calls 7683 verifySettlement on source chain, triggering T1XChainReader.requestRead
-    // 4a. relayer picks up message and calls getFilledOrderStatus on destination chain
-    // 4b. relayer calls T1XChainReader.handle with the result of the read which calls
-    // onT1XChainReaderResult on callback address
-    // 4c. onT1XChainReaderResult on 7683 contract settles intent and releases funds to solver
-    function test_ERC7683PullSettlementFlow() public {
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+    // Verify the final state on L1
+    assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
+  }
 
-        // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
-        {
-            // Construct the read request calldata
-            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-            uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-            uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+  function test_handleSucceededCallback() public {
+    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-            assertEq(
-                balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
-            );
-        }
+    // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
+    {
+      // Construct the read request calldata
+      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
 
-        // Verify the final state on L1
-        assertTrue(L1T17683Pull.orderVerified(orderId), "Order should be verified");
+      vm.expectEmit(true, true, true, true);
+      emit BaseT1XChainReader.ReadSucceeded(requestId, orderStatus);
+      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
     }
+  }
 
-    function test_handleGenericFailedCallback() public {
-        (,, bytes32 requestId) = _openAndFillOrder();
+  function test_handleGenericFailedCallback() public {
+    (, , bytes32 requestId) = _openAndFillOrder();
 
-        // 4. Attempt to process the read request on L2
-        {
-            // Construct bad read request calldata
-            bytes memory orderStatus = hex"11";
-            bytes memory revertReason = hex"";
-            vm.expectEmit(true, true, true, true);
-            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-            originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-        }
+    // 4. Attempt to process the read request on L2
+    {
+      // Construct bad read request calldata
+      bytes memory orderStatus = hex"11";
+      bytes memory revertReason = hex"";
+      vm.expectEmit(true, true, true, true);
+      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+      originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
     }
+  }
 
-    function test_handleCustomFailedCallback() public {
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-        bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
-        // 4. Attempt to process the read request on L2
-        {
-            // Construct bad read request calldata
-            bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
-            bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
-            vm.expectEmit(true, true, true, true);
-            emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
-            originReader.handle(destination, badSender, requestId, orderStatus);
-        }
+  function test_handleCustomFailedCallback() public {
+    (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+    bytes32 badSender = TypeCasts.addressToBytes32(address(0xbeef));
+    // 4. Attempt to process the read request on L2
+    {
+      // Construct bad read request calldata
+      bytes memory orderStatus = L2T17683Pull.getFilledOrderStatus(orderId);
+      bytes memory revertReason = abi.encodeWithSelector(T1ERC7683Pull.SettlementFailed.selector);
+      vm.expectEmit(true, true, true, true);
+      emit BaseT1XChainReader.ReadFailed(requestId, orderStatus, revertReason);
+      originReader.handle(destination, badSender, requestId, orderStatus);
     }
+  }
 
-    function test_onlyProver_revert() public {
-        bytes32 requestId = hex"";
-        bytes memory orderStatus = hex"";
+  function test_handleRevertStringFailedCallback() public {
+    BaseT1XChainReader.ReadRequest memory readRequest = BaseT1XChainReader.ReadRequest({
+            destinationDomain: uint32(0),
+            targetContract: address(0),
+            minBlock: 0,
+            callData: hex"",
+            callback: address(mockCallbackContract)
+    });
+    bytes32 requestId = originReader.requestRead(readRequest);
 
-        vm.prank(address(0xbeef));
-        vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
-        originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
-    }
+    string memory revertReason = "revert!";
+    vm.expectEmit(true, true, true, true);
+    emit BaseT1XChainReader.ReadFailed(requestId, hex"", revertReason);
+    originReader.handle(destination, bytes32(0), requestId, hex"");
+  }
 
-    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
-        OrderData memory orderData = _prepareOrderData();
-        OnchainCrossChainOrder memory order =
-            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+  function test_onlyProver_revert() public {
+    bytes32 requestId = hex"";
+    bytes memory orderStatus = hex"";
 
-        vm.startPrank(kakaroto);
-        inputToken.approve(address(L1T17683Pull), amount);
-        vm.recordLogs();
-        L1T17683Pull.open(order);
-        vm.stopPrank();
+    vm.prank(address(0xbeef));
+    vm.expectRevert(BaseT1XChainReader.OnlyProver.selector);
+    originReader.handle(destination, destinationRouterB32, requestId, orderStatus);
+  }
 
-        (bytes32 orderId_,) = _getOrderIDFromLogs();
-        assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
+  function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+    OrderData memory orderData = _prepareOrderData();
+    OnchainCrossChainOrder memory order = _prepareOnchainOrder(
+      OrderEncoder.encode(orderData),
+      orderData.fillDeadline,
+      OrderEncoder.orderDataType()
+    );
 
-        vm.startPrank(vegeta);
-        outputToken.approve(address(L2T17683Pull), amount);
-        bytes memory originData = OrderEncoder.encode(orderData);
-        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
-        L2T17683Pull.fill(orderId_, originData, fillerData);
-        assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
-        vm.stopPrank();
+    vm.startPrank(kakaroto);
+    inputToken.approve(address(L1T17683Pull), amount);
+    vm.recordLogs();
+    L1T17683Pull.open(order);
+    vm.stopPrank();
 
-        vm.startPrank(vegeta);
-        bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
-        vm.stopPrank();
+    (bytes32 orderId_, ) = _getOrderIDFromLogs();
+    assertEq(L1T17683Pull.orderStatus(orderId_), _base7683.OPENED());
 
-        return (orderData, orderId_, requestId_);
-    }
+    vm.startPrank(vegeta);
+    outputToken.approve(address(L2T17683Pull), amount);
+    bytes memory originData = OrderEncoder.encode(orderData);
+    bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+    L2T17683Pull.fill(orderId_, originData, fillerData);
+    assertEq(L2T17683Pull.orderStatus(orderId_), L2T17683Pull.FILLED());
+    vm.stopPrank();
+
+    vm.startPrank(vegeta);
+    bytes32 requestId_ = L1T17683Pull.verifySettlement(destination, orderId_);
+    vm.stopPrank();
+
+    return (orderData, orderId_, requestId_);
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* refactor `BaseT1XChainReader.sol`: add try/catch to `onT1XChainReaderResult` call
* test `T1XChainReaderTest`: add tests for `ReadFailed` reverts + refactor test setups to be DRY
<!--- Describe your changes in detail -->

## Motivation and Context
To gracefully handle errors originating from the callback contract. The benefit of this is approach is that the error is visible and overt for the user. Reverting at the top level means that the callback would fail at the gas estimation step, meaning the user never even sees the result of their xCR request delivered, and has no information about why it failed. With this try/catch, the user will see the reason.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Added 2 tests
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
-   [x] This change includes any required documentation updates.
-   [x] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [x] This change includes any required test coverage.
-   [x] The version has been bumped according to our internal semantic versioning rules˚¬˚