### PR TITLE
ERC-7683 deployment scripts for Arbitrum Sepolia and Base Sepolia

### DIFF
--- a/contracts/deployments/7683/v0.4.0.json
+++ b/contracts/deployments/7683/v0.4.0.json
@@ -1,0 +1,49 @@
+{
+  "metadata": {
+    "version": "v0.4.0",
+    "date": "2025-05-19",
+    "by": "Evan",
+    "from_machine": "Evan's machine",
+    "from_branch": "feature/deploy-messengers-to-arb-and-base",
+    "from_tag": "v0.4.0"
+  },
+  "addresses": {
+    "arbitrum_sepolia": {
+      "signer": "0xD99c1b45708a4E94c6230f6A77BD7fa729f5398B",
+      "usdt": "0xF6232a871BF3B33F5bc181f55d770F9FB062A457",
+      "t1ProxyAdmin": "0xaec234f08C3acE19cE1FA477e4DcBdEFd9000ecb",
+      "proxyImplementationPlaceholder": "0x0C80EC2129C72fE022fe33DEE826983DBEC72452",
+      "t1MessengerProxy": "0xd31aDB0eF8A31e081f29A9f07F594a71B88848c1",
+      "t1MessageQueue": "0x5Fe327F7268f38f4a964DaFdFB709826F1C2a409",
+      "t1MessengerImplementation": "0x2Ae1A629e64337F540f4E8eD94e665BF792656a3",
+      "t1Owner": "0xFc30645d98ecF37823BeCbf0CDf86f09e886365a",
+      "t1XChainRead": {
+        "implementation": "0x65949C0471cb12A4b82Dc0Cef4d52553f4a9A2aE",
+        "proxy": "0x0fD87D072B5C7E51bD1Bc3B1c75B2a9F9fE9Fe58"
+      },
+      "t1PullBased7683": {
+        "implementation": "0xfab428425a128245a489bc22f729A673eaeAb719",
+        "proxy": "0x172F4579F1927c12b6bC38A1D19bB841a704b81B"
+      }
+    },
+    "base_sepolia": {
+      "signer": "0xD99c1b45708a4E94c6230f6A77BD7fa729f5398B",
+      "usdt": "0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC",
+      "t1ProxyAdmin": "0xaec234f08C3acE19cE1FA477e4DcBdEFd9000ecb",
+      "proxyImplementationPlaceholder": "0x0C80EC2129C72fE022fe33DEE826983DBEC72452",
+      "t1MessengerProxy": "0xd31aDB0eF8A31e081f29A9f07F594a71B88848c1",
+      "t1MessageQueue": "0x5Fe327F7268f38f4a964DaFdFB709826F1C2a409",
+      "t1MessengerImplementation": "0x2Ae1A629e64337F540f4E8eD94e665BF792656a3",
+      "t1Owner": "0xFc30645d98ecF37823BeCbf0CDf86f09e886365a",
+      "t1XChainRead": {
+        "implementation": "0x65949C0471cb12A4b82Dc0Cef4d52553f4a9A2aE",
+        "proxy": "0x0fD87D072B5C7E51bD1Bc3B1c75B2a9F9fE9Fe58"
+      },
+      "t1PullBased7683": {
+        "implementation": "0xfab428425a128245a489bc22f729A673eaeAb719",
+        "proxy": "0x172F4579F1927c12b6bC38A1D19bB841a704b81B"
+      }
+    },
+    "deployerAddress": "0xD99c1b45708a4E94c6230f6A77BD7fa729f5398B"
+  }
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -57,9 +57,11 @@
   polygon = "https://polygon-mainnet.infura.io/v3/${API_KEY_INFURA}"
   sepolia = "${T1_L1_RPC}"
   t1 = "${T1_L2_RPC}"
+  arbitrum_sepolia = "${ARBITRUM_SEPOLIA_RPC}"
   base_sepolia = "${BASE_SEPOLIA_RPC}"
 
 [etherscan]
 sepolia = { key = "${ETHERSCAN_API_KEY}" }
 base_sepolia = { key = "${BASESCAN_API_KEY}" }
+arbitrum_sepolia = { key = "${ARBITRUM_API_KEY}" }
 

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -117,43 +117,104 @@ Scripts to upgrade contract implementations:
 
 ## Deploying 7683Pull to Arbitrum Sepolia and Base Sepolia
 
+This section walks you through deploying all pieces of the 7683Pull system to both Arbitrum Sepolia and Base Sepolia
+testnets. You’ll deploy messenger proxies, their implementations (with initialization), ownership transfers, the
+cross-chain reader, and finally the ERC-7683 pull modules. Each Forge script broadcasts the tx, verifies it on the right
+explorer API, and uses your API key to confirm source code.
+
 ### Deploying Messengers & Friends
+
+Deploy the proxy, impl, init and ownership hand-off for the t1 messenger contract on each network.
+
+#### Arbitrum Sepolia Messenger Proxy
+
+Deploys the upgradeable proxy that fronts the messenger logic and verifies it on Arbiscan.
+
 ```bash
 forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerProxy --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
+
+#### Base Sepolia Messenger Proxy
+
+Same as above, but targets Base Sepolia and verifies on Basescan.
+
 ```bash
 forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerProxy --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
+
+#### Arbitrum Sepolia Messenger Impl & Init
+
+Deploys the messenger implementation, runs its init() to set up state, then verifies on Arbiscan.
+
 ```bash
 forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerImplAndInit --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
+
+#### Base Sepolia Messenger Impl & Init
+
+Same deployment and init flow for Base Sepolia, verified on Basescan.
+
 ```bash
 forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerImplAndInit --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
+
+#### Arbitrum Sepolia Ownership Transfer
+
+Deploys a short‐lived owner contract and immediately hands proxy ownership to the governance module.
+
 ```bash
 forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerOwnerAndTransferOwnership --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
+
+#### Base Sepolia Ownership Transfer
+
+Mirror of the above on Base Sepolia.
+
 ```bash
 forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerOwnerAndTransferOwnership --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 
 ### Deploying xChainRead
+
+Deploys the xChainReader contract, which packages cross-chain read requests and handles callbacks to the requesting
+contracts.
+
+#### Arbitrum Sepolia XChain Reader
+
 ```bash
 forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
+
+#### Base Sepolia XChain Reader
+
 ```bash
 forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
+
 ### Deploying 7683
+
+Deploys ERC-7683 contracts to the target chain, verifies and initializes them.
+
+#### Arbitrum Sepolia Pull Module Deployment
+
 ```bash
 forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "deploy()"  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
+
+#### Base Sepolia Pull Module Deployment
+
 ```bash
 forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "deploy()" --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
+
+#### Arbitrum Sepolia Pull Module Init
+
 ```bash
 forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "init()" --broadcast
 ```
+
+#### Base Sepolia Pull Module Init
+
 ```bash
 forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "init()" --broadcast
 ```

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -114,3 +114,29 @@ Scripts to upgrade contract implementations:
   ```bash
   forge script ./script/upgrade/UpgradeT1Chain.s.sol:UpgradeT1Chain --rpc-url $T1_L1_RPC --broadcast
   ```
+
+## Deploying 7683Pull to Arbitrum Sepolia and Base Sepolia
+
+### Deploying Messengers & Friends
+```bash
+forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployProxy()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+```
+```bash
+forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployProxy()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+```
+```bash
+forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployImplAndInit()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+```
+```bash
+forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployImplAndInit()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+```
+```bash
+forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployOwnerAndTransferOwnership()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+```
+```bash
+forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployOwnerAndTransferOwnership()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+```
+
+### Deploying xChainRead
+
+### Deploying 7683Pull

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -44,7 +44,7 @@ To deploy the 7683 contract, follow these steps:
 First, deploy the L1 router by running the following command:
 
 ```bash
-forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL1Router()" --rpc-url $T1_L1_RPC --broadcast --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.etherscan.io/api
+forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL1Router()" --rpc-url $T1_L1_RPC --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.etherscan.io/api
 ```
 
 ### Deploy L2 Router
@@ -52,7 +52,7 @@ forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig
 Next, deploy the L2 router with the following command:
 
 ```bash
-forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL2Router()" --rpc-url $T1_L2_RPC --broadcast --broadcast --verify --verifier blockscout --verifier-url https://explorer.devnet.t1protocol.com/api
+forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL2Router()" --rpc-url $T1_L2_RPC --broadcast --verify --verifier blockscout --verifier-url https://explorer.devnet.t1protocol.com/api
 ```
 
 ### Initialize Functions

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -44,7 +44,7 @@ To deploy the 7683 contract, follow these steps:
 First, deploy the L1 router by running the following command:
 
 ```bash
-forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL1Router()" --rpc-url $T1_L1_RPC --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.etherscan.io/api
+forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL1Router()" --rpc-url $T1_L1_RPC --broadcast --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.etherscan.io/api
 ```
 
 ### Deploy L2 Router
@@ -52,7 +52,7 @@ forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig
 Next, deploy the L2 router with the following command:
 
 ```bash
-forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL2Router()" --rpc-url $T1_L2_RPC --broadcast --verify --verifier blockscout --verifier-url https://explorer.devnet.t1protocol.com/api
+forge script ./script/deploy/7683/DeployT1ERC7683.s.sol:RouterDeployScript --sig "deployL2Router()" --rpc-url $T1_L2_RPC --broadcast --broadcast --verify --verifier blockscout --verifier-url https://explorer.devnet.t1protocol.com/api
 ```
 
 ### Initialize Functions
@@ -119,24 +119,29 @@ Scripts to upgrade contract implementations:
 
 ### Deploying Messengers & Friends
 ```bash
-forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployProxy()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerProxy --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
 ```bash
-forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployProxy()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerProxy --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 ```bash
-forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployImplAndInit()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerImplAndInit --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
 ```bash
-forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployImplAndInit()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerImplAndInit --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 ```bash
-forge script DeployArbT1Messenger.s.sol:DeployArbT1Messenger --sig "deployOwnerAndTransferOwnership()" --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+forge script ./deploy/DeployArbT1Messenger.s.sol:DeployArbT1MessengerOwnerAndTransferOwnership --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
 ```bash
-forge script DeployBaseT1Messenger.s.sol:DeployBaseT1Messenger --sig "deployOwnerAndTransferOwnership()" --verify --verifier etherscan --verifier-url https://api-base.arbiscan.io/api --etherscan-api-key $BASESCAN_API_KEY
+forge script ./deploy/DeployBaseT1Messenger.s.sol:DeployBaseT1MessengerOwnerAndTransferOwnership --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 
 ### Deploying xChainRead
-
+```bash
+forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+```
+```bash
+forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
+```
 ### Deploying 7683Pull

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -145,15 +145,15 @@ forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader  --b
 forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 ### Deploying 7683
-```
+```bash
 forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "deploy()"  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
-```
+```bash
 forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "deploy()" --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
-```
+```bash
 forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "init()" --broadcast
 ```
-```
+```bash
 forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "init()" --broadcast
 ```

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -144,4 +144,16 @@ forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader  --b
 ```bash
 forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
-### Deploying 7683Pull
+### Deploying 7683
+```
+forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "deploy()"  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+```
+```
+forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "deploy()" --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
+```
+```
+forge script ./deploy/7683/DeployArbT1ERC7683Pull.s.sol:DeployArbT1ERC7683Pull --sig "init()" --broadcast
+```
+```
+forge script ./deploy/7683/DeployBaseT1ERC7683Pull.s.sol:DeployBaseT1ERC7683Pull --sig "init()" --broadcast
+```

--- a/contracts/script/deploy/7683/DeployArbBaseT1ERC7683Pull.s.sol
+++ b/contracts/script/deploy/7683/DeployArbBaseT1ERC7683Pull.s.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { DeploymentUtils } from "../../lib/DeploymentUtils.sol";
+
+import { T1ERC7683Pull } from "../../../src/7683/T1ERC7683Pull.sol";
+import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
+
+contract DeployArbBaseT1ERC7683Pull is DeploymentUtils {
+    uint32 internal constant ARB = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
+    uint32 internal constant BASE = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
+    ProxyAdmin private proxyAdmin;
+
+    function arb_deploy() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        logStart("DeployT1ERC7683Pull to Arbitrum");
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_X_CHAIN_READ_PROXY_ADDR = vm.envAddress("ARB_T1_X_CHAIN_READ_PROXY_ADDR");
+        address ARB_PROXY_ADMIN_ADDR = vm.envAddress("ARB_PROXY_ADMIN_ADDR");
+        proxyAdmin = ProxyAdmin(ARB_PROXY_ADMIN_ADDR);
+
+        vm.startBroadcast(deployerPk);
+
+        // Deploy 7683 implementation
+        T1ERC7683Pull impl = new T1ERC7683Pull(
+            address(0), // No Permit2 for now
+            ARB_T1_X_CHAIN_READ_PROXY_ADDR,
+            ARB
+        );
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+
+        vm.stopBroadcast();
+
+        logAddress("ARB_T1_PULL_BASED_7683_IMPLEMENTATION_ADDR", address(impl));
+        logAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR", address(proxy));
+
+        logEnd("DeployT1ERC7683Pull to Arbitrum");
+    }
+
+    function arb_init() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_7683_PROXY_ADDR = vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR");
+        address BASE_T1_7683_PROXY_ADDR = vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR");
+
+        vm.startBroadcast(deployerPk);
+
+        T1ERC7683Pull(ARB_T1_7683_PROXY_ADDR).initialize(BASE_T1_7683_PROXY_ADDR);
+
+        vm.stopBroadcast();
+    }
+
+    function base_deploy() external {
+        logStart("DeployT1ERC7683Pull to Base");
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address BASE_T1_X_CHAIN_READ_PROXY_ADDR = vm.envAddress("BASE_T1_X_CHAIN_READ_PROXY_ADDR");
+        address BASE_PROXY_ADMIN_ADDR = vm.envAddress("BASE_PROXY_ADMIN_ADDR");
+
+        vm.startBroadcast(deployerPk);
+
+        proxyAdmin = ProxyAdmin(BASE_PROXY_ADMIN_ADDR);
+
+        // Deploy 7683 implementation
+        T1ERC7683Pull impl = new T1ERC7683Pull(
+            address(0), // No Permit2 for now
+            BASE_T1_X_CHAIN_READ_PROXY_ADDR,
+            BASE
+        );
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+
+        vm.stopBroadcast();
+        logAddress("BASE_T1_PULL_BASED_7683_IMPLEMENTATION_ADDR", address(impl));
+        logAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR", address(proxy));
+        logEnd("DeployT1ERC7683Pull to Base");
+    }
+
+    function base_init() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_7683_PROXY_ADDR = vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR");
+        address BASE_T1_7683_PROXY_ADDR = vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR");
+
+        vm.startBroadcast(deployerPk);
+
+        T1ERC7683Pull(BASE_T1_7683_PROXY_ADDR).initialize(ARB_T1_7683_PROXY_ADDR);
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/deploy/7683/DeployArbT1ERC7683Pull.s.sol
+++ b/contracts/script/deploy/7683/DeployArbT1ERC7683Pull.s.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { DeploymentUtils } from "../../lib/DeploymentUtils.sol";
+
+import { T1ERC7683Pull } from "../../../src/7683/T1ERC7683Pull.sol";
+import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
+
+contract DeployArbT1ERC7683Pull is DeploymentUtils {
+    uint32 internal constant ARB = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
+    uint32 internal constant BASE = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
+    ProxyAdmin private proxyAdmin;
+
+    function deploy() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        logStart("DeployT1ERC7683Pull to Arbitrum");
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_X_CHAIN_READ_PROXY_ADDR = vm.envAddress("ARB_T1_X_CHAIN_READ_PROXY_ADDR");
+        address ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
+        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+
+        vm.startBroadcast(deployerPk);
+
+        // Deploy 7683 implementation
+        T1ERC7683Pull impl = new T1ERC7683Pull(
+            address(0), // No Permit2 for now
+            ARB_T1_X_CHAIN_READ_PROXY_ADDR,
+            ARB
+        );
+
+        // Deploy and initialize proxy
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+
+        vm.stopBroadcast();
+
+        logAddress("ARB_T1_PULL_BASED_7683_IMPLEMENTATION_ADDR", address(impl));
+        logAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR", address(proxy));
+
+        logEnd("DeployT1ERC7683Pull to Arbitrum");
+    }
+
+    function init() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_7683_PROXY_ADDR = vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR");
+        address BASE_T1_7683_PROXY_ADDR = vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR");
+
+        vm.startBroadcast(deployerPk);
+
+        T1ERC7683Pull(ARB_T1_7683_PROXY_ADDR).initialize(BASE_T1_7683_PROXY_ADDR);
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/deploy/7683/DeployArbT1ERC7683Pull.s.sol
+++ b/contracts/script/deploy/7683/DeployArbT1ERC7683Pull.s.sol
@@ -24,14 +24,12 @@ contract DeployArbT1ERC7683Pull is DeploymentUtils {
 
         vm.startBroadcast(deployerPk);
 
-        // Deploy 7683 implementation
         T1ERC7683Pull impl = new T1ERC7683Pull(
             address(0), // No Permit2 for now
             ARB_T1_X_CHAIN_READ_PROXY_ADDR,
             ARB
         );
 
-        // Deploy and initialize proxy
         TransparentUpgradeableProxy proxy =
             new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
 

--- a/contracts/script/deploy/7683/DeployBaseT1ERC7683Pull.s.sol
+++ b/contracts/script/deploy/7683/DeployBaseT1ERC7683Pull.s.sol
@@ -9,63 +9,21 @@ import { DeploymentUtils } from "../../lib/DeploymentUtils.sol";
 import { T1ERC7683Pull } from "../../../src/7683/T1ERC7683Pull.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 
-contract DeployArbBaseT1ERC7683Pull is DeploymentUtils {
+contract DeployBaseT1ERC7683Pull is DeploymentUtils {
     uint32 internal constant ARB = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
     uint32 internal constant BASE = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
     ProxyAdmin private proxyAdmin;
 
-    function arb_deploy() external {
-        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        logStart("DeployT1ERC7683Pull to Arbitrum");
-        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
-        address ARB_T1_X_CHAIN_READ_PROXY_ADDR = vm.envAddress("ARB_T1_X_CHAIN_READ_PROXY_ADDR");
-        address ARB_PROXY_ADMIN_ADDR = vm.envAddress("ARB_PROXY_ADMIN_ADDR");
-        proxyAdmin = ProxyAdmin(ARB_PROXY_ADMIN_ADDR);
-
-        vm.startBroadcast(deployerPk);
-
-        // Deploy 7683 implementation
-        T1ERC7683Pull impl = new T1ERC7683Pull(
-            address(0), // No Permit2 for now
-            ARB_T1_X_CHAIN_READ_PROXY_ADDR,
-            ARB
-        );
-
-        // Deploy and initialize proxy
-        TransparentUpgradeableProxy proxy =
-            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
-
-        vm.stopBroadcast();
-
-        logAddress("ARB_T1_PULL_BASED_7683_IMPLEMENTATION_ADDR", address(impl));
-        logAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR", address(proxy));
-
-        logEnd("DeployT1ERC7683Pull to Arbitrum");
-    }
-
-    function arb_init() external {
-        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
-        address ARB_T1_7683_PROXY_ADDR = vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR");
-        address BASE_T1_7683_PROXY_ADDR = vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR");
-
-        vm.startBroadcast(deployerPk);
-
-        T1ERC7683Pull(ARB_T1_7683_PROXY_ADDR).initialize(BASE_T1_7683_PROXY_ADDR);
-
-        vm.stopBroadcast();
-    }
-
-    function base_deploy() external {
+    function deploy() external {
         logStart("DeployT1ERC7683Pull to Base");
         vm.createSelectFork(vm.rpcUrl("base_sepolia"));
         uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
         address BASE_T1_X_CHAIN_READ_PROXY_ADDR = vm.envAddress("BASE_T1_X_CHAIN_READ_PROXY_ADDR");
-        address BASE_PROXY_ADMIN_ADDR = vm.envAddress("BASE_PROXY_ADMIN_ADDR");
+        address BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
 
         vm.startBroadcast(deployerPk);
 
-        proxyAdmin = ProxyAdmin(BASE_PROXY_ADMIN_ADDR);
+        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
 
         // Deploy 7683 implementation
         T1ERC7683Pull impl = new T1ERC7683Pull(
@@ -84,7 +42,7 @@ contract DeployArbBaseT1ERC7683Pull is DeploymentUtils {
         logEnd("DeployT1ERC7683Pull to Base");
     }
 
-    function base_init() external {
+    function init() external {
         vm.createSelectFork(vm.rpcUrl("base_sepolia"));
         uint256 deployerPk = vm.envUint("DEPLOYER_PRIVATE_KEY");
         address ARB_T1_7683_PROXY_ADDR = vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR");

--- a/contracts/script/deploy/7683/DeployBaseT1ERC7683Pull.s.sol
+++ b/contracts/script/deploy/7683/DeployBaseT1ERC7683Pull.s.sol
@@ -25,14 +25,12 @@ contract DeployBaseT1ERC7683Pull is DeploymentUtils {
 
         proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
 
-        // Deploy 7683 implementation
         T1ERC7683Pull impl = new T1ERC7683Pull(
             address(0), // No Permit2 for now
             BASE_T1_X_CHAIN_READ_PROXY_ADDR,
             BASE
         );
 
-        // Deploy and initialize proxy
         TransparentUpgradeableProxy proxy =
             new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
 

--- a/contracts/script/deploy/7683/DeployT1ERC7683.s.sol
+++ b/contracts/script/deploy/7683/DeployT1ERC7683.s.sol
@@ -24,14 +24,12 @@ contract DeployT1ERC7683 is Script {
 
         proxyAdmin = ProxyAdmin(L1_PROXY_ADMIN_ADDR);
 
-        // Deploy L1 router implementation
         T1ERC7683 implementation = new T1ERC7683(
             l1Messenger,
             address(0), // No Permit2 for now
             ORIGIN_CHAIN
         );
 
-        // Deploy and initialize proxy
         TransparentUpgradeableProxy proxy =
             new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), new bytes(0));
 
@@ -71,7 +69,6 @@ contract DeployT1ERC7683 is Script {
             DESTINATION_CHAIN
         );
 
-        // Deploy and initialize proxy
         TransparentUpgradeableProxy proxy =
             new TransparentUpgradeableProxy(address(implementation), address(proxyAdmin), new bytes(0));
 

--- a/contracts/script/deploy/DeployArbT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployArbT1Messenger.s.sol
@@ -14,44 +14,19 @@ import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-contract DeployArbT1Messenger is Script, DeploymentUtils  {
-    uint256 private deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
-    address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
-    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
-    address private ARB_T1_MESSENGER_IMPLEMENTATION_ADDR = vm.envAddress("ARB_T1_MESSENGER_IMPLEMENTATION_ADDR");
-    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+contract DeployArbT1MessengerProxy is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
     ProxyAdmin private proxyAdmin;
     EmptyContract private placeholder;
-    L2MessageQueue private queue;
-    L2T1Messenger private impl;
     TransparentUpgradeableProxy private proxy;
-    T1Owner private owner;
 
-    function deployProxy() external {
+    function run() external {
         vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
         vm.startBroadcast(deployerPrivateKey);
         deployProxyAdmin();
         deployPlaceHolder();
         deployT1MessengerProxy();
-    }
-
-    function deployImplAndInit() external {
-        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        vm.startBroadcast(deployerPrivateKey);
-        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
-        proxy = TransparentUpgradeableProxy(payable(ARB_T1_MESSENGER_PROXY_ADDR));
-        deployMessageQueue();
-        deployT1MessengerImpl();
-        upgradeAndInitializeT1MessengerProxy();
-    }
-
-    function deployOwnerAndTransferOwnership() internal {
-        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        vm.startBroadcast(deployerPrivateKey);
-        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
-        deployT1Owner();
-        transferOwnership();
     }
 
     function deployProxyAdmin() internal {
@@ -72,6 +47,28 @@ contract DeployArbT1Messenger is Script, DeploymentUtils  {
 
         logAddress("ARB_T1_MESSENGER_PROXY_ADDR", address(proxy));
     }
+}
+
+contract DeployArbT1MessengerImplAndInit is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
+    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    L2MessageQueue private queue;
+    L2T1Messenger private impl;
+    TransparentUpgradeableProxy private proxy;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+        proxy = TransparentUpgradeableProxy(payable(ARB_T1_MESSENGER_PROXY_ADDR));
+        deployMessageQueue();
+        deployT1MessengerImpl();
+        upgradeAndInitializeT1MessengerProxy();
+    }
 
     function deployMessageQueue() internal {
         address deployer = vm.addr(deployerPrivateKey);
@@ -87,7 +84,6 @@ contract DeployArbT1Messenger is Script, DeploymentUtils  {
     }
 
     function upgradeAndInitializeT1MessengerProxy() internal {
-
         proxyAdmin.upgrade(
             ITransparentUpgradeableProxy(address(proxy)), address(impl)
         );
@@ -95,6 +91,22 @@ contract DeployArbT1Messenger is Script, DeploymentUtils  {
         uint64[] memory network = new uint64[](1);
         network[0] = T1Constants.BASE_SEPOLIA_CHAIN_ID;
         L2T1Messenger(payable(address(proxy))).initialize(BASE_T1_MESSENGER_PROXY_ADDR, network);
+    }
+}
+
+contract DeployArbT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    T1Owner private owner;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+        deployT1Owner();
+        transferOwnership();
     }
 
     function deployT1Owner() internal {

--- a/contracts/script/deploy/DeployArbT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployArbT1Messenger.s.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+import { EmptyContract } from "../../src/misc/EmptyContract.sol";
+import { L2T1Messenger } from "../../src/L2/L2T1Messenger.sol";
+import { T1Constants } from "../../src/libraries/constants/T1Constants.sol";
+import { L2MessageQueue } from "../../src/L2/predeploys/L2MessageQueue.sol";
+import { T1Owner } from "../../src/misc/T1Owner.sol";
+
+import { Script } from "forge-std/Script.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract DeployArbT1Messenger is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
+    address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
+    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+    address private ARB_T1_MESSENGER_IMPLEMENTATION_ADDR = vm.envAddress("ARB_T1_MESSENGER_IMPLEMENTATION_ADDR");
+    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    EmptyContract private placeholder;
+    L2MessageQueue private queue;
+    L2T1Messenger private impl;
+    TransparentUpgradeableProxy private proxy;
+    T1Owner private owner;
+
+    function deployProxy() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        deployProxyAdmin();
+        deployPlaceHolder();
+        deployT1MessengerProxy();
+    }
+
+    function deployImplAndInit() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+        proxy = TransparentUpgradeableProxy(payable(ARB_T1_MESSENGER_PROXY_ADDR));
+        deployMessageQueue();
+        deployT1MessengerImpl();
+        upgradeAndInitializeT1MessengerProxy();
+    }
+
+    function deployOwnerAndTransferOwnership() internal {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+        deployT1Owner();
+        transferOwnership();
+    }
+
+    function deployProxyAdmin() internal {
+        proxyAdmin = new ProxyAdmin();
+        logAddress("ARB_T1_PROXY_ADMIN_ADDR", address(proxyAdmin));
+    }
+
+    function deployPlaceHolder() internal {
+        placeholder = new EmptyContract();
+
+        logAddress("ARB_PROXY_IMPLEMENTATION_PLACEHOLDER_ADDR", address(placeholder));
+    }
+
+    function deployT1MessengerProxy() internal {
+        proxy = new TransparentUpgradeableProxy(
+            address(placeholder), address(proxyAdmin), new bytes(0)
+        );
+
+        logAddress("ARB_T1_MESSENGER_PROXY_ADDR", address(proxy));
+    }
+
+    function deployMessageQueue() internal {
+        address deployer = vm.addr(deployerPrivateKey);
+        queue = new L2MessageQueue(deployer);
+
+        logAddress("ARB_T1_MESSAGE_QUEUE_ADDR", address(queue));
+    }
+
+    function deployT1MessengerImpl() internal {
+        impl = new L2T1Messenger(BASE_T1_MESSENGER_PROXY_ADDR, address(queue));
+
+        logAddress("ARB_T1_MESSENGER_IMPLEMENTATION_ADDR", address(impl));
+    }
+
+    function upgradeAndInitializeT1MessengerProxy() internal {
+
+        proxyAdmin.upgrade(
+            ITransparentUpgradeableProxy(address(proxy)), address(impl)
+        );
+
+        uint64[] memory network = new uint64[](1);
+        network[0] = T1Constants.BASE_SEPOLIA_CHAIN_ID;
+        L2T1Messenger(payable(address(proxy))).initialize(BASE_T1_MESSENGER_PROXY_ADDR, network);
+    }
+
+    function deployT1Owner() internal {
+        owner = new T1Owner();
+        logAddress("ARB_T1_OWNER_ADDR", address(owner));
+    }
+
+    function transferOwnership() internal {
+        Ownable(proxyAdmin).transferOwnership(address(owner));
+    }
+}

--- a/contracts/script/deploy/DeployArbT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployArbT1Messenger.s.sol
@@ -14,7 +14,7 @@ import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-contract DeployArbT1MessengerProxy is Script, DeploymentUtils  {
+contract DeployArbT1MessengerProxy is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
     ProxyAdmin private proxyAdmin;
@@ -41,15 +41,13 @@ contract DeployArbT1MessengerProxy is Script, DeploymentUtils  {
     }
 
     function deployT1MessengerProxy() internal {
-        proxy = new TransparentUpgradeableProxy(
-            address(placeholder), address(proxyAdmin), new bytes(0)
-        );
+        proxy = new TransparentUpgradeableProxy(address(placeholder), address(proxyAdmin), new bytes(0));
 
         logAddress("ARB_T1_MESSENGER_PROXY_ADDR", address(proxy));
     }
 }
 
-contract DeployArbT1MessengerImplAndInit is Script, DeploymentUtils  {
+contract DeployArbT1MessengerImplAndInit is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
     address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
@@ -84,9 +82,7 @@ contract DeployArbT1MessengerImplAndInit is Script, DeploymentUtils  {
     }
 
     function upgradeAndInitializeT1MessengerProxy() internal {
-        proxyAdmin.upgrade(
-            ITransparentUpgradeableProxy(address(proxy)), address(impl)
-        );
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(proxy)), address(impl));
 
         uint64[] memory network = new uint64[](1);
         network[0] = T1Constants.BASE_SEPOLIA_CHAIN_ID;
@@ -94,7 +90,7 @@ contract DeployArbT1MessengerImplAndInit is Script, DeploymentUtils  {
     }
 }
 
-contract DeployArbT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils  {
+contract DeployArbT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address private ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
 

--- a/contracts/script/deploy/DeployArbT1XChainReader.s.sol
+++ b/contracts/script/deploy/DeployArbT1XChainReader.s.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+
+import { T1XChainReader } from "../../src/libraries/xChain/T1XChainReader.sol";
+
+contract DeployArbT1XChainReader is DeploymentUtils {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        logStart("DeployXChainRead to ARB");
+
+        uint256 DEPLOYER_PRIVATE_KEY = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+        address ARB_T1_PROXY_ADMIN_ADDR = vm.envAddress("ARB_T1_PROXY_ADMIN_ADDR");
+        address SIGNER = vm.envAddress("ARB_SIGNER");
+        ProxyAdmin proxyAdmin = ProxyAdmin(ARB_T1_PROXY_ADMIN_ADDR);
+
+        vm.startBroadcast(DEPLOYER_PRIVATE_KEY);
+
+        T1XChainReader impl = new T1XChainReader(address(ARB_T1_MESSENGER_PROXY_ADDR), SIGNER);
+        logAddress("ARB_T1_X_CHAIN_READ_IMPLEMENTATION_ADDR", address(impl));
+
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+        logAddress("ARB_T1_X_CHAIN_READ_PROXY_ADDR", address(proxy));
+
+        vm.stopBroadcast();
+
+        logEnd("DeployXChainRead to ARB");
+    }
+}

--- a/contracts/script/deploy/DeployBaseT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployBaseT1Messenger.s.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.25;
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+import { EmptyContract } from "../../src/misc/EmptyContract.sol";
+import { L2T1Messenger } from "../../src/L2/L2T1Messenger.sol";
+import { T1Constants } from "../../src/libraries/constants/T1Constants.sol";
+import { L2MessageQueue } from "../../src/L2/predeploys/L2MessageQueue.sol";
+import { T1Owner } from "../../src/misc/T1Owner.sol";
+
+import { Script } from "forge-std/Script.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+contract DeployBaseT1Messenger is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
+    address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
+    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+    address private BASE_T1_MESSENGER_IMPLEMENTATION_ADDR = vm.envAddress("BASE_T1_MESSENGER_IMPLEMENTATION_ADDR");
+    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    EmptyContract private placeholder;
+    L2MessageQueue private queue;
+    L2T1Messenger private impl;
+    TransparentUpgradeableProxy private proxy;
+    T1Owner private owner;
+    function deployProxy() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        deployProxyAdmin();
+        deployPlaceHolder();
+        deployT1MessengerProxy();
+    }
+
+    function deployImplAndInit() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
+        proxy = TransparentUpgradeableProxy(payable(BASE_T1_MESSENGER_PROXY_ADDR));
+        deployMessageQueue();
+        deployT1MessengerImpl();
+        upgradeAndInitializeT1MessengerProxy();
+    }
+
+    function deployOwnerAndTransferOwnership() internal {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
+        deployT1Owner();
+        transferOwnership();
+    }
+
+    function deployProxyAdmin() internal {
+        proxyAdmin = new ProxyAdmin();
+
+        logAddress("BASE_T1_PROXY_ADMIN_ADDR", address(proxyAdmin));
+    }
+
+    function deployPlaceHolder() internal {
+        placeholder = new EmptyContract();
+
+        logAddress("BASE_PROXY_IMPLEMENTATION_PLACEHOLDER_ADDR", address(placeholder));
+    }
+
+    function deployT1MessengerProxy() internal {
+        proxy = new TransparentUpgradeableProxy(
+            address(placeholder), address(proxyAdmin), new bytes(0)
+        );
+
+        logAddress("BASE_T1_MESSENGER_PROXY_ADDR", address(proxy));
+    }
+
+    function deployMessageQueue() internal {
+        address deployer = vm.addr(deployerPrivateKey);
+        queue = new L2MessageQueue(deployer);
+
+        logAddress("BASE_T1_MESSAGE_QUEUE_ADDR", address(queue));
+    }
+
+    function deployT1MessengerImpl() internal {
+        impl = new L2T1Messenger(BASE_T1_MESSENGER_PROXY_ADDR, address(queue));
+
+        logAddress("BASE_T1_MESSENGER_IMPLEMENTATION_ADDR", address(impl));
+    }
+
+    function upgradeAndInitializeT1MessengerProxy() internal {
+
+        proxyAdmin.upgrade(
+            ITransparentUpgradeableProxy(address(proxy)), address(impl)
+        );
+
+        uint64[] memory network = new uint64[](1);
+        network[0] = T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID;
+        L2T1Messenger(payable(address(proxy))).initialize(ARB_T1_MESSENGER_PROXY_ADDR, network);
+    }
+
+    function deployT1Owner() internal {
+        owner = new T1Owner();
+        logAddress("BASE_T1_OWNER_ADDR", address(owner));
+    }
+
+    function transferOwnership() internal {
+        Ownable(proxyAdmin).transferOwnership(address(owner));
+    }
+}

--- a/contracts/script/deploy/DeployBaseT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployBaseT1Messenger.s.sol
@@ -14,20 +14,14 @@ import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-contract DeployBaseT1Messenger is Script, DeploymentUtils  {
-    uint256 private deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
-    address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
-    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
-    address private BASE_T1_MESSENGER_IMPLEMENTATION_ADDR = vm.envAddress("BASE_T1_MESSENGER_IMPLEMENTATION_ADDR");
-    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+contract DeployBaseT1MessengerProxy is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
     ProxyAdmin private proxyAdmin;
     EmptyContract private placeholder;
-    L2MessageQueue private queue;
-    L2T1Messenger private impl;
     TransparentUpgradeableProxy private proxy;
-    T1Owner private owner;
-    function deployProxy() external {
+
+    function run() external {
         vm.createSelectFork(vm.rpcUrl("base_sepolia"));
         vm.startBroadcast(deployerPrivateKey);
         deployProxyAdmin();
@@ -35,27 +29,8 @@ contract DeployBaseT1Messenger is Script, DeploymentUtils  {
         deployT1MessengerProxy();
     }
 
-    function deployImplAndInit() external {
-        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
-        vm.startBroadcast(deployerPrivateKey);
-        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
-        proxy = TransparentUpgradeableProxy(payable(BASE_T1_MESSENGER_PROXY_ADDR));
-        deployMessageQueue();
-        deployT1MessengerImpl();
-        upgradeAndInitializeT1MessengerProxy();
-    }
-
-    function deployOwnerAndTransferOwnership() internal {
-        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
-        vm.startBroadcast(deployerPrivateKey);
-        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
-        deployT1Owner();
-        transferOwnership();
-    }
-
     function deployProxyAdmin() internal {
         proxyAdmin = new ProxyAdmin();
-
         logAddress("BASE_T1_PROXY_ADMIN_ADDR", address(proxyAdmin));
     }
 
@@ -72,6 +47,28 @@ contract DeployBaseT1Messenger is Script, DeploymentUtils  {
 
         logAddress("BASE_T1_MESSENGER_PROXY_ADDR", address(proxy));
     }
+}
+
+contract DeployBaseT1MessengerImplAndInit is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
+    address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+    address private ARB_T1_MESSENGER_PROXY_ADDR = vm.envAddress("ARB_T1_MESSENGER_PROXY_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    L2MessageQueue private queue;
+    L2T1Messenger private impl;
+    TransparentUpgradeableProxy private proxy;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
+        proxy = TransparentUpgradeableProxy(payable(BASE_T1_MESSENGER_PROXY_ADDR));
+        deployMessageQueue();
+        deployT1MessengerImpl();
+        upgradeAndInitializeT1MessengerProxy();
+    }
 
     function deployMessageQueue() internal {
         address deployer = vm.addr(deployerPrivateKey);
@@ -87,7 +84,6 @@ contract DeployBaseT1Messenger is Script, DeploymentUtils  {
     }
 
     function upgradeAndInitializeT1MessengerProxy() internal {
-
         proxyAdmin.upgrade(
             ITransparentUpgradeableProxy(address(proxy)), address(impl)
         );
@@ -95,6 +91,22 @@ contract DeployBaseT1Messenger is Script, DeploymentUtils  {
         uint64[] memory network = new uint64[](1);
         network[0] = T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID;
         L2T1Messenger(payable(address(proxy))).initialize(ARB_T1_MESSENGER_PROXY_ADDR, network);
+    }
+}
+
+contract DeployBaseT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils  {
+    uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
+    address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
+
+    ProxyAdmin private proxyAdmin;
+    T1Owner private owner;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        vm.startBroadcast(deployerPrivateKey);
+        proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
+        deployT1Owner();
+        transferOwnership();
     }
 
     function deployT1Owner() internal {

--- a/contracts/script/deploy/DeployBaseT1Messenger.s.sol
+++ b/contracts/script/deploy/DeployBaseT1Messenger.s.sol
@@ -14,7 +14,7 @@ import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 
-contract DeployBaseT1MessengerProxy is Script, DeploymentUtils  {
+contract DeployBaseT1MessengerProxy is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
 
     ProxyAdmin private proxyAdmin;
@@ -41,15 +41,13 @@ contract DeployBaseT1MessengerProxy is Script, DeploymentUtils  {
     }
 
     function deployT1MessengerProxy() internal {
-        proxy = new TransparentUpgradeableProxy(
-            address(placeholder), address(proxyAdmin), new bytes(0)
-        );
+        proxy = new TransparentUpgradeableProxy(address(placeholder), address(proxyAdmin), new bytes(0));
 
         logAddress("BASE_T1_MESSENGER_PROXY_ADDR", address(proxy));
     }
 }
 
-contract DeployBaseT1MessengerImplAndInit is Script, DeploymentUtils  {
+contract DeployBaseT1MessengerImplAndInit is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
     address private BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
@@ -84,9 +82,7 @@ contract DeployBaseT1MessengerImplAndInit is Script, DeploymentUtils  {
     }
 
     function upgradeAndInitializeT1MessengerProxy() internal {
-        proxyAdmin.upgrade(
-            ITransparentUpgradeableProxy(address(proxy)), address(impl)
-        );
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(address(proxy)), address(impl));
 
         uint64[] memory network = new uint64[](1);
         network[0] = T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID;
@@ -94,7 +90,7 @@ contract DeployBaseT1MessengerImplAndInit is Script, DeploymentUtils  {
     }
 }
 
-contract DeployBaseT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils  {
+contract DeployBaseT1MessengerOwnerAndTransferOwnership is Script, DeploymentUtils {
     uint256 private deployerPrivateKey = vm.envUint("DEPLOYER_PRIVATE_KEY");
     address private BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
 

--- a/contracts/script/deploy/DeployBaseT1XChainReader.s.sol
+++ b/contracts/script/deploy/DeployBaseT1XChainReader.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+import { T1XChainReader } from "../../src/libraries/xChain/T1XChainReader.sol";
+
+contract DeployBaseT1XChainReader is DeploymentUtils {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        logStart("DeployXChainRead to BASE");
+
+        uint256 DEPLOYER_PRIVATE_KEY = vm.envUint("DEPLOYER_PRIVATE_KEY");
+        address BASE_T1_MESSENGER_PROXY_ADDR = vm.envAddress("BASE_T1_MESSENGER_PROXY_ADDR");
+        address BASE_T1_PROXY_ADMIN_ADDR = vm.envAddress("BASE_T1_PROXY_ADMIN_ADDR");
+        address SIGNER = vm.envAddress("BASE_SIGNER");
+        ProxyAdmin proxyAdmin = ProxyAdmin(BASE_T1_PROXY_ADMIN_ADDR);
+
+        vm.startBroadcast(DEPLOYER_PRIVATE_KEY);
+
+        T1XChainReader impl = new T1XChainReader(address(BASE_T1_MESSENGER_PROXY_ADDR), SIGNER);
+        logAddress("BASE_T1_X_CHAIN_READ_IMPLEMENTATION_ADDR", address(impl));
+
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+        logAddress("BASE_T1_X_CHAIN_READ_PROXY_ADDR", address(proxy));
+
+        vm.stopBroadcast();
+
+        logEnd("DeployXChainRead to BASE");
+    }
+}

--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -85,7 +85,7 @@ contract AliceSetupScript is Script {
 contract SolverFillScript is Script {
     function run() external {
         vm.createSelectFork(vm.rpcUrl("base_sepolia"));
-        uint256 solverPk = vm.envUint("TEST_PRIVATE_KEY");  // TODO CHANGE
+        uint256 solverPk = vm.envUint("TEST_PRIVATE_KEY");
         address solver = vm.addr(solverPk);
 
         vm.startBroadcast(solverPk);

--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -7,7 +7,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
 import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
-import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
+import { T1ERC7683Pull } from "../../../src/7683/T1ERC7683Pull.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 
 uint32 constant ORIGIN_CHAIN = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
@@ -15,11 +15,11 @@ uint32 constant DESTINATION_CHAIN = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
 
 // Step 1: Setup Alice's account, sign and relay intent
 contract AliceSetupScript is Script {
-    T1ERC7683 public l1Router;
+    T1ERC7683Pull public l1Router;
 
     function run() external {
         vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        l1Router = T1ERC7683(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR"));
+        l1Router = T1ERC7683Pull(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR"));
         // Load Alice's private key from env
         uint256 alicePk = vm.envUint("ALICE_PRIVATE_KEY");
         address alice = vm.addr(alicePk);
@@ -91,7 +91,7 @@ contract SolverFillScript is Script {
         vm.startBroadcast(solverPk);
 
         // Get order details
-        T1ERC7683 l2Router = T1ERC7683(vm.envAddress("L2_T1_7683_PROXY_ADDR"));
+        T1ERC7683Pull l2Router = T1ERC7683Pull(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR"));
         // NOTE - orderId logged from the first step goes here (remove 0x first)
         bytes32 orderId = hex"";
 
@@ -99,7 +99,7 @@ contract SolverFillScript is Script {
         bytes memory originData = hex"";
 
         // Approve output tokens
-        ERC20(vm.envAddress("L2_USDT_ADDR")).approve(
+        ERC20(vm.envAddress("BASE_SEPOLIA_USDT_ADDR")).approve(
             address(l2Router),
             100 // match amount from order
         );
@@ -112,22 +112,20 @@ contract SolverFillScript is Script {
     }
 }
 
-// Step 3: Settlement and Relay
+// Step 3: Pull Based Settlement and Relay
 contract SettlementScript is Script {
     function run() external {
-        vm.createSelectFork(vm.rpcUrl("t1"));
-        uint256 settlerPk = vm.envUint("TEST_PRIVATE_KEY");
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        uint256 settlerPk = vm.envUint("ALICE_PRIVATE_KEY");
 
         vm.startBroadcast(settlerPk);
 
-        T1ERC7683 l2Router = T1ERC7683(vm.envAddress("L2_T1_7683_PROXY_ADDR"));
+        T1ERC7683Pull l1Router = T1ERC7683Pull(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR"));
 
-        // Prepare order IDs and filler data for batch settlement
-        bytes32[] memory orderIds = new bytes32[](1);
         // NOTE - orderId logged from the first step goes here (remove 0x first)
-        orderIds[0] = hex"";
+        bytes32 orderId = hex"";
 
-        l2Router.settle{ value: 0 }(orderIds);
+        l1Router.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
 
         vm.stopBroadcast();
     }

--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
+import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
+
+uint32 constant ORIGIN_CHAIN = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
+uint32 constant DESTINATION_CHAIN = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
+
+// Step 1: Setup Alice's account, sign and relay intent
+contract AliceSetupScript is Script {
+    T1ERC7683 public l1Router;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        l1Router = T1ERC7683(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR"));
+        // Load Alice's private key from env
+        uint256 alicePk = vm.envUint("ALICE_PRIVATE_KEY");
+        address alice = vm.addr(alicePk);
+
+        // Start broadcasting as Alice
+        vm.startBroadcast(alicePk);
+
+        // Approve tokens
+        ERC20 inputToken = ERC20(vm.envAddress("ARBITRUM_SEPOLIA_USDT_ADDR"));
+        ERC20 outputToken = ERC20(vm.envAddress("BASE_SEPOLIA_USDT_ADDR"));
+        inputToken.approve(address(l1Router), type(uint256).max);
+
+        // Prepare order data
+        OrderData memory orderData = OrderData({
+            sender: TypeCasts.addressToBytes32(alice),
+            recipient: TypeCasts.addressToBytes32(alice),
+            inputToken: TypeCasts.addressToBytes32(address(inputToken)),
+            outputToken: TypeCasts.addressToBytes32(address(outputToken)),
+            amountIn: 100,
+            amountOut: 100,
+            senderNonce: uint32(
+                uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, msg.sender))) % 10_000
+            ), // Random number between 0 and 9999
+            originDomain: ORIGIN_CHAIN,
+            destinationDomain: DESTINATION_CHAIN,
+            destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR")),
+            fillDeadline: uint32(block.timestamp + 24 hours),
+            data: new bytes(0)
+        });
+
+        bytes memory encodedOrder = OrderEncoder.encode(orderData);
+
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(encodedOrder, orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        l1Router.open(order);
+
+        bytes32 id = OrderEncoder.id(orderData);
+        console2.logString("orderId: ");
+        console2.logBytes32(id);
+
+        console2.log("encodedOrder: ");
+        console2.logBytes(encodedOrder);
+
+        vm.stopBroadcast();
+    }
+
+    function _prepareOnchainOrder(
+        bytes memory orderData,
+        uint32 fillDeadline,
+        bytes32 orderDataType
+    )
+        internal
+        pure
+        returns (OnchainCrossChainOrder memory)
+    {
+        return
+            OnchainCrossChainOrder({ fillDeadline: fillDeadline, orderDataType: orderDataType, orderData: orderData });
+    }
+}
+
+// Step 2: Solver fills on L2
+contract SolverFillScript is Script {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        uint256 solverPk = vm.envUint("TEST_PRIVATE_KEY");  // TODO CHANGE
+        address solver = vm.addr(solverPk);
+
+        vm.startBroadcast(solverPk);
+
+        // Get order details
+        T1ERC7683 l2Router = T1ERC7683(vm.envAddress("L2_T1_7683_PROXY_ADDR"));
+        // NOTE - orderId logged from the first step goes here (remove 0x first)
+        bytes32 orderId = hex"";
+
+        // NOTE - encodedOrder logged from the first step goes here
+        bytes memory originData = hex"";
+
+        // Approve output tokens
+        ERC20(vm.envAddress("L2_USDT_ADDR")).approve(
+            address(l2Router),
+            100 // match amount from order
+        );
+
+        // Fill the order
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(solver));
+        l2Router.fill(orderId, originData, fillerData);
+
+        vm.stopBroadcast();
+    }
+}
+
+// Step 3: Settlement and Relay
+contract SettlementScript is Script {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("t1"));
+        uint256 settlerPk = vm.envUint("TEST_PRIVATE_KEY");
+
+        vm.startBroadcast(settlerPk);
+
+        T1ERC7683 l2Router = T1ERC7683(vm.envAddress("L2_T1_7683_PROXY_ADDR"));
+
+        // Prepare order IDs and filler data for batch settlement
+        bytes32[] memory orderIds = new bytes32[](1);
+        // NOTE - orderId logged from the first step goes here (remove 0x first)
+        orderIds[0] = hex"";
+
+        l2Router.settle{ value: 0 }(orderIds);
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { T1ERC7683Pull } from "../../../src/7683/T1ERC7683Pull.sol";
+import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
+
+uint32 constant ORIGIN_CHAIN = uint32(T1Constants.BASE_SEPOLIA_CHAIN_ID);
+uint32 constant DESTINATION_CHAIN = uint32(T1Constants.ARBITRUM_SEPOLIA_CHAIN_ID);
+
+// Step 1: Setup Alice's account, sign and relay intent
+contract AliceSetupScript is Script {
+    T1ERC7683Pull public l1Router;
+
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        l1Router = T1ERC7683Pull(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR"));
+        // Load Alice's private key from env
+        uint256 alicePk = vm.envUint("ALICE_PRIVATE_KEY");
+        address alice = vm.addr(alicePk);
+
+        // Start broadcasting as Alice
+        vm.startBroadcast(alicePk);
+
+        // Approve tokens
+        ERC20 inputToken = ERC20(vm.envAddress("BASE_SEPOLIA_USDT_ADDR"));
+        ERC20 outputToken = ERC20(vm.envAddress("ARBITRUM_SEPOLIA_USDT_ADDR"));
+        inputToken.approve(address(l1Router), type(uint256).max);
+
+        // Prepare order data
+        OrderData memory orderData = OrderData({
+            sender: TypeCasts.addressToBytes32(alice),
+            recipient: TypeCasts.addressToBytes32(alice),
+            inputToken: TypeCasts.addressToBytes32(address(inputToken)),
+            outputToken: TypeCasts.addressToBytes32(address(outputToken)),
+            amountIn: 100,
+            amountOut: 100,
+            senderNonce: uint32(
+                uint256(keccak256(abi.encodePacked(block.timestamp, block.prevrandao, msg.sender))) % 10_000
+            ), // Random number between 0 and 9999
+            originDomain: ORIGIN_CHAIN,
+            destinationDomain: DESTINATION_CHAIN,
+            destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR")),
+            fillDeadline: uint32(block.timestamp + 24 hours),
+            data: new bytes(0)
+        });
+
+        bytes memory encodedOrder = OrderEncoder.encode(orderData);
+
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(encodedOrder, orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        l1Router.open(order);
+
+        bytes32 id = OrderEncoder.id(orderData);
+        console2.logString("orderId: ");
+        console2.logBytes32(id);
+
+        console2.log("encodedOrder: ");
+        console2.logBytes(encodedOrder);
+
+        vm.stopBroadcast();
+    }
+
+    function _prepareOnchainOrder(
+        bytes memory orderData,
+        uint32 fillDeadline,
+        bytes32 orderDataType
+    )
+        internal
+        pure
+        returns (OnchainCrossChainOrder memory)
+    {
+        return
+            OnchainCrossChainOrder({ fillDeadline: fillDeadline, orderDataType: orderDataType, orderData: orderData });
+    }
+}
+
+// Step 2: Solver fills on L2
+contract SolverFillScript is Script {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
+        uint256 solverPk = vm.envUint("TEST_PRIVATE_KEY");
+        address solver = vm.addr(solverPk);
+
+        vm.startBroadcast(solverPk);
+
+        // Get order details
+        T1ERC7683Pull l2Router = T1ERC7683Pull(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR"));
+        // NOTE - orderId logged from the first step goes here (remove 0x first)
+        bytes32 orderId = hex"";
+
+        // NOTE - encodedOrder logged from the first step goes here
+        bytes memory originData = hex"";
+
+        // Approve output tokens
+        ERC20(vm.envAddress("ARBITRUM_SEPOLIA_USDT_ADDR")).approve(
+            address(l2Router),
+            100 // match amount from order
+        );
+
+        // Fill the order
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(solver));
+        l2Router.fill(orderId, originData, fillerData);
+
+        vm.stopBroadcast();
+    }
+}
+
+// Step 3: Pull Based Settlement and Relay
+contract SettlementScript is Script {
+    function run() external {
+        vm.createSelectFork(vm.rpcUrl("base_sepolia"));
+        uint256 settlerPk = vm.envUint("ALICE_PRIVATE_KEY");
+
+        vm.startBroadcast(settlerPk);
+
+        T1ERC7683Pull l1Router = T1ERC7683Pull(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR"));
+
+        // NOTE - orderId logged from the first step goes here (remove 0x first)
+        bytes32 orderId = hex"";
+
+        l1Router.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
+
+        vm.stopBroadcast();
+    }
+}

--- a/contracts/src/libraries/constants/T1Constants.sol
+++ b/contracts/src/libraries/constants/T1Constants.sol
@@ -19,6 +19,9 @@ library T1Constants {
     /// @notice Chain ID of the Base Sepolia network
     uint64 internal constant BASE_SEPOLIA_CHAIN_ID = 84_532;
 
+    /// @notice Chain ID of the Arbitrum Sepolia network
+    uint64 internal constant ARBITRUM_SEPOLIA_CHAIN_ID = 421_614;
+
     /// @notice The EIP-712 type string for the remaining after the witness.
     string internal constant WITNESS_TYPE_STRING =
     // solhint-disable-next-line max-line-length


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
* Added Forge scripts to automate deployment of the following contracts to Arbitrum Sepolia and Base Sepolia:
  * `t1ProxyAdmin`: auxiliary contract assigned as the admin of TransparentUpgradeableProxys.
  * `proxyImplementationPlaceholder`: deploy a minimal Ownable‐style contract whose sole job is to call the proxy-admin’s `transferOwnership`.
  * `t1MessengerProxy`/`t1MessengerImplementation`: handles emitting `SentMessage` events which are picked up as read requests by the off-chain relayer.
  *  `t1Owner`: manages upgrading contracts and calling permissioned methods.
  * `t1XChainRead`: packages cross-chain read requests and handles callbacks to the requesting contracts.
  * `t1PullBased7683`: handles cross-chain intents using the ERC-7683 standard
<!--- Describe your changes in detail -->

## Motivation and Context
To deploy our ERC-7683 implementation to the target environment for what we call "v0.4" milestone
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on v0.4.0 in both directions
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] This change includes any required documentation updates.
-   [x] I have added/updated any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.).
-   [x] This change includes any required test coverage.
-   [ ] The version has been bumped according to our internal semantic versioning rules˚¬˚