### PR TITLE
Fix missing reference in e2e tsconfig

### DIFF
--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -12,11 +12,7 @@
     "isolatedModules": true,
     "noFallthroughCasesInSwitch": true,
     "strictPropertyInitialization": false,
+    "skipLibCheck": true,
   },
-  "references": [
-    {
-      "path": "../sdk"
-    }
-  ],
   "exclude": ["node_modules", "dist"],
 }


### PR DESCRIPTION
## Summary
- remove reference to a non-existent sdk project from e2e tsconfig
- enable `skipLibCheck` so TypeScript builds without Node type errors

## Testing
- `bun install` in `e2e`
- `npx tsc --noEmit -p e2e/tsconfig.json`
- `TEST_ENV=canary npx jest --config ./jest.testnet.config.ts --bail --runInBand` *(fails due to missing env vars)*
- `cargo test --manifest-path reth/Cargo.toml --no-default-features` *(fails to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684616ded09c8331b4a9b16a09209cee