### PR TITLE
Release: v0.5.0 + xChainReader fixes

### DIFF
--- a/contracts/.env.template
+++ b/contracts/.env.template
@@ -1,12 +1,10 @@
 # ---------------------------------------------------------
 # BEGIN CHAINS CONFIG
 # ---------------------------------------------------------
-# START SECRET
-T1_L1_RPC=https://eth-sepolia.g.alchemy.com/v2/8J9Q6Q6Q9Q6Q9Q6Q9Q6Q9Q6Q9Q6Q9Q6
-#T1_L1_RPC=https://sepolia.infura.io/v3/XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-# END SECRET
-T1_L2_RPC=http://127.0.0.1:8545
-BASE_SEPOLIA_RPC=http://127.0.0.1:8645
+T1_L1_RPC=
+T1_L2_RPC=
+ARBITRUM_SEPOLIA_RPC=
+BASE_SEPOLIA_RPC=
 CHAIN_ID_L2=
 # ---------------------------------------------------------
 # END CHAINS CONFIG
@@ -16,6 +14,7 @@ CHAIN_ID_L2=
 # BEGIN 1Password PRIVATE KEYS
 # ---------------------------------------------------------
 # START SECRET
+DEPLOYER_PRIVATE_KEY=
 L1_DEPLOYER_PRIVATE_KEY=
 L2_DEPLOYER_PRIVATE_KEY=
 BASE_DEPLOYER_PRIVATE_KEY=
@@ -36,6 +35,7 @@ L2_7683_BOT_PRIVATE_KEY=
 BLOCKSCOUT_API_URL="http://127.0.0.1/api?"
 # START SECRET
 ETHERSCAN_API_KEY=
+ARBISCAN_API_KEY=
 BASESCAN_API_KEY=
 # END SECRET
 # ---------------------------------------------------------
@@ -79,6 +79,15 @@ L2_14D_TIMELOCK_ADDR=0xA42CA2A6b3707FB3837e1Ad2Cd5B5382dfbFf75f
 L1_USDT_ADDR=0x6f78c1A39e193C404f8a424beCdcf84216103B38
 L1_WETH_ADDR=0x7b79995e5f793A07Bc00c21412e50Ecae098E7f9
 L1_PERMIT2=0x000000000022D473030F116dDEE9F6B43aC78BA3
+
 # ---------------------------------------------------------
 # END CONSTANT ADDRESSES
 # ---------------------------------------------------------
+
+ARB_T1_MESSENGER_PROXY_ADDR=
+ARB_T1_PROXY_ADMIN_ADDR=
+ARB_SIGNER=
+
+BASE_T1_MESSENGER_PROXY_ADDR=
+BASE_T1_PROXY_ADMIN_ADDR=
+BASE_SIGNER=

--- a/contracts/.solhint.json
+++ b/contracts/.solhint.json
@@ -10,7 +10,7 @@
         "ignoreConstructors": true
       }
     ],
-    "max-line-length": ["error", 121],
+    "max-line-length": "off",
     "named-parameters-mapping": "warn",
     "no-console": "off",
     "not-rely-on-time": "off",

--- a/contracts/bun.lock
+++ b/contracts/bun.lock
@@ -7,7 +7,6 @@
         "@openzeppelin/contracts": "4.9.3",
         "@openzeppelin/contracts-upgradeable": "4.9.3",
         "@uniswap/permit2": "github:uniswap/permit2",
-        "intents-framework": "github:BootNodeDev/intents-framework#main",
       },
       "devDependencies": {
         "ds-test": "github:dapphub/ds-test",
@@ -381,8 +380,6 @@
     "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "intents-framework": ["@bootnodedev/intents-framework@github:BootNodeDev/intents-framework#62a181f", {}, "BootNodeDev-intents-framework-62a181f"],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 

--- a/contracts/deployments/7683/v0.5.0.json
+++ b/contracts/deployments/7683/v0.5.0.json
@@ -1,0 +1,51 @@
+{
+  "metadata": {
+    "version": "v0.5.0",
+    "date": "2025-06-09",
+    "by": "Evan",
+    "from_machine": "Evan's machine",
+    "from_branch": "canary",
+    "from_commit": "6fc4564fcae4e9bb4d522a106e545441e2cf67e7"
+  },
+  "addresses": {
+    "arbitrum_sepolia": {
+      "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
+      "usdt": "0xF6232a871BF3B33F5bc181f55d770F9FB062A457",
+      "weth": "0x2836ae2eA2c013acD38028fD0C77B92cccFa2EE4",
+      "t1ProxyAdmin": "0xDa708C7DedFe27b503d22f7ef92631F6f66Efe5f",
+      "proxyImplementationPlaceholder": "0xf9A4188C7E62948f6fE3F91D9382986e89B18306",
+      "t1MessengerProxy": "0x2C11eD12b97D68dc08ddcC5788C81B50702Ff703",
+      "t1MessageQueue": "0x684bF0d23B4b0681A3E1e57529abaE784Ce3A9a7",
+      "t1MessengerImplementation": "0x66E2Ad6D0bB8E4318c8627E050011935dDfE7714",
+      "t1Owner": "0x148FbAF99B7EfaB598eE5E4d9dbAbf79ae486119",
+      "t1XChainRead": {
+        "implementation": "0x885f8432246d83fcc8ee2ac0368B6763Cc01f813",
+        "proxy": "0xE2c0D41348aF3ce1F94bcB03e872C238D1B5D646"
+      },
+      "t1ERC7683": {
+        "implementation": "0xbe3EaF2c2d9760B2A69720e823096150B8F33b53",
+        "proxy": "0x237992cb3df5Bbc0A527f4F0d8f7C9B1d935C84A"
+      }
+    },
+    "base_sepolia": {
+      "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
+      "usdt": "0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC",
+      "weth": "0x4200000000000000000000000000000000000006",
+      "t1ProxyAdmin": "0xE45960210313884b55059D60B9C67b7308C3aa51",
+      "proxyImplementationPlaceholder": "0x2E9d9eEEDD73335a6f88F27d71fe28eCb294f0F8",
+      "t1MessengerProxy": "0x698f80F5573e7749A4F6cF776EbA6231bb73A368",
+      "t1MessageQueue": "0xDa708C7DedFe27b503d22f7ef92631F6f66Efe5f",
+      "t1MessengerImplementation": "0xf9A4188C7E62948f6fE3F91D9382986e89B18306",
+      "t1Owner": "0x66E2Ad6D0bB8E4318c8627E050011935dDfE7714",
+      "t1XChainRead": {
+        "implementation": "0x561846e0CAd7Bb975A83d7d93be0A3Cba069100d",
+        "proxy": "0x148FbAF99B7EfaB598eE5E4d9dbAbf79ae486119"
+      },
+      "t1ERC7683": {
+        "implementation": "0x631DCEd9bec639b9F71772C997D6162A9b0b287E",
+        "proxy": "0x885f8432246d83fcc8ee2ac0368B6763Cc01f813"
+      }
+    },
+    "deployerAddress": "0xB458Ff684cCEDb45Be3a41584B7a25fD5FCcB10F"
+  }
+}

--- a/contracts/deployments/7683/v0.5.0.json
+++ b/contracts/deployments/7683/v0.5.0.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
     "version": "v0.5.0",
-    "date": "2025-06-09",
+    "date": "2025-06-12",
     "by": "Evan",
     "from_machine": "Evan's machine",
     "from_branch": "canary",
@@ -12,38 +12,38 @@
       "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
       "usdt": "0xF6232a871BF3B33F5bc181f55d770F9FB062A457",
       "weth": "0x2836ae2eA2c013acD38028fD0C77B92cccFa2EE4",
-      "t1ProxyAdmin": "0xDa708C7DedFe27b503d22f7ef92631F6f66Efe5f",
-      "proxyImplementationPlaceholder": "0xf9A4188C7E62948f6fE3F91D9382986e89B18306",
-      "t1MessengerProxy": "0x2C11eD12b97D68dc08ddcC5788C81B50702Ff703",
-      "t1MessageQueue": "0x684bF0d23B4b0681A3E1e57529abaE784Ce3A9a7",
-      "t1MessengerImplementation": "0x66E2Ad6D0bB8E4318c8627E050011935dDfE7714",
-      "t1Owner": "0x148FbAF99B7EfaB598eE5E4d9dbAbf79ae486119",
+      "t1ProxyAdmin": "0x55d816956F86dE3f6091f981fa64Ba7d367547d5",
+      "proxyImplementationPlaceholder": "0x999b53b0E8CA9CBCF606b29Bc44cFD93fFc4b367",
+      "t1MessengerProxy": "0x87F7FD6a609D72bb4cCeEDbD191C6ED23b830b98",
+      "t1MessageQueue": "0x48f2405110d244b7FD6C405838dd0A942FDfF887",
+      "t1MessengerImplementation": "0x98420A065d8718031D4ca177db7d7e17E6aA37B2",
+      "t1Owner": "0x0896CFAcf23CA844a6282F81496cAFD3F0A39f7F",
       "t1XChainRead": {
-        "implementation": "0x885f8432246d83fcc8ee2ac0368B6763Cc01f813",
-        "proxy": "0xE2c0D41348aF3ce1F94bcB03e872C238D1B5D646"
+        "implementation": "0x2acFd06b22686b1883D1e037966Ca9105Ab6b74D",
+        "proxy": "0x63336D1fB48fb78784ebCf07B40660a64eBEfcd9"
       },
       "t1ERC7683": {
-        "implementation": "0xbe3EaF2c2d9760B2A69720e823096150B8F33b53",
-        "proxy": "0x237992cb3df5Bbc0A527f4F0d8f7C9B1d935C84A"
+        "implementation": "0x4f8198F4F12Aec57a11B78560213d7bDbFD2b8FE",
+        "proxy": "0xEae1A3Ea173b8dee3Da8EA43Ea75400fC084611E"
       }
     },
     "base_sepolia": {
       "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
       "usdt": "0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC",
       "weth": "0x4200000000000000000000000000000000000006",
-      "t1ProxyAdmin": "0xE45960210313884b55059D60B9C67b7308C3aa51",
-      "proxyImplementationPlaceholder": "0x2E9d9eEEDD73335a6f88F27d71fe28eCb294f0F8",
-      "t1MessengerProxy": "0x698f80F5573e7749A4F6cF776EbA6231bb73A368",
-      "t1MessageQueue": "0xDa708C7DedFe27b503d22f7ef92631F6f66Efe5f",
-      "t1MessengerImplementation": "0xf9A4188C7E62948f6fE3F91D9382986e89B18306",
-      "t1Owner": "0x66E2Ad6D0bB8E4318c8627E050011935dDfE7714",
+      "t1ProxyAdmin": "0x4f8198F4F12Aec57a11B78560213d7bDbFD2b8FE",
+      "proxyImplementationPlaceholder": "0xEae1A3Ea173b8dee3Da8EA43Ea75400fC084611E",
+      "t1MessengerProxy": "0xAD4cDb3AF4b203bd7aa6F71d1ee1372Dbb87D65e",
+      "t1MessageQueue": "0xf3Fd7Ff45b28E76f4fD14ca86c1208c8F8E6dB72",
+      "t1MessengerImplementation": "0xF597A13758Afa19228AbAc7882Bca9544882cc24",
+      "t1Owner": "0x424a96cF24bac989f2930cf2A2913b0DE7d431C8",
       "t1XChainRead": {
-        "implementation": "0x561846e0CAd7Bb975A83d7d93be0A3Cba069100d",
-        "proxy": "0x148FbAF99B7EfaB598eE5E4d9dbAbf79ae486119"
+        "implementation": "0x8862fC66c29D06DB19f54f9202FCb4A11610279E",
+        "proxy": "0x2Ee22Dc359bb3b6Cd6442933Bb59676078c0F3d0"
       },
       "t1ERC7683": {
-        "implementation": "0x631DCEd9bec639b9F71772C997D6162A9b0b287E",
-        "proxy": "0x885f8432246d83fcc8ee2ac0368B6763Cc01f813"
+        "implementation": "0xA9d7eF9942396d521E89ceDBa4dB4A912F567466",
+        "proxy": "0x9Ad015CfA892b21d947b73d98d3D9Cd906b88fDF"
       }
     },
     "deployerAddress": "0xB458Ff684cCEDb45Be3a41584B7a25fD5FCcB10F"

--- a/contracts/deployments/7683/v0.5.0.json
+++ b/contracts/deployments/7683/v0.5.0.json
@@ -1,49 +1,49 @@
 {
   "metadata": {
     "version": "v0.5.0",
-    "date": "2025-06-12",
+    "date": "2025-06-13",
     "by": "Evan",
     "from_machine": "Evan's machine",
     "from_branch": "canary",
-    "from_commit": "6fc4564fcae4e9bb4d522a106e545441e2cf67e7"
+    "from_commit": "10c1b46607559120aeb7c32b846202d25634a23c"
   },
   "addresses": {
     "arbitrum_sepolia": {
       "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
       "usdt": "0xF6232a871BF3B33F5bc181f55d770F9FB062A457",
       "weth": "0x2836ae2eA2c013acD38028fD0C77B92cccFa2EE4",
-      "t1ProxyAdmin": "0x55d816956F86dE3f6091f981fa64Ba7d367547d5",
-      "proxyImplementationPlaceholder": "0x999b53b0E8CA9CBCF606b29Bc44cFD93fFc4b367",
-      "t1MessengerProxy": "0x87F7FD6a609D72bb4cCeEDbD191C6ED23b830b98",
-      "t1MessageQueue": "0x48f2405110d244b7FD6C405838dd0A942FDfF887",
-      "t1MessengerImplementation": "0x98420A065d8718031D4ca177db7d7e17E6aA37B2",
-      "t1Owner": "0x0896CFAcf23CA844a6282F81496cAFD3F0A39f7F",
+      "t1ProxyAdmin": "0xf3Fd7Ff45b28E76f4fD14ca86c1208c8F8E6dB72",
+      "proxyImplementationPlaceholder": "0xF597A13758Afa19228AbAc7882Bca9544882cc24",
+      "t1MessengerProxy": "0xF5612cD25eaAB4fF8EC5d4ff42b1CB5a8C794f28",
+      "t1MessageQueue": "0xAC93df286c7ee81d5A76b6b1f52C78b4f4110A7d",
+      "t1MessengerImplementation": "0x424a96cF24bac989f2930cf2A2913b0DE7d431C8",
+      "t1Owner": "0x2Ee22Dc359bb3b6Cd6442933Bb59676078c0F3d0",
       "t1XChainRead": {
-        "implementation": "0x2acFd06b22686b1883D1e037966Ca9105Ab6b74D",
-        "proxy": "0x63336D1fB48fb78784ebCf07B40660a64eBEfcd9"
+        "implementation": "0x9Ad015CfA892b21d947b73d98d3D9Cd906b88fDF",
+        "proxy": "0x42d389A9007e446b92C0ce7bd8F42Ea10292881B"
       },
       "t1ERC7683": {
-        "implementation": "0x4f8198F4F12Aec57a11B78560213d7bDbFD2b8FE",
-        "proxy": "0xEae1A3Ea173b8dee3Da8EA43Ea75400fC084611E"
+        "implementation": "0xC0b5456e40c2A032DC98A39d455f5ea7d4AB1C9d",
+        "proxy": "0x4727D2EC7b602628980BE1E1a4e99d39A45786A4"
       }
     },
     "base_sepolia": {
       "signer": "0x33c5A1e60E228814789F3b6178C15010a8087664",
       "usdt": "0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC",
       "weth": "0x4200000000000000000000000000000000000006",
-      "t1ProxyAdmin": "0x4f8198F4F12Aec57a11B78560213d7bDbFD2b8FE",
-      "proxyImplementationPlaceholder": "0xEae1A3Ea173b8dee3Da8EA43Ea75400fC084611E",
-      "t1MessengerProxy": "0xAD4cDb3AF4b203bd7aa6F71d1ee1372Dbb87D65e",
-      "t1MessageQueue": "0xf3Fd7Ff45b28E76f4fD14ca86c1208c8F8E6dB72",
-      "t1MessengerImplementation": "0xF597A13758Afa19228AbAc7882Bca9544882cc24",
-      "t1Owner": "0x424a96cF24bac989f2930cf2A2913b0DE7d431C8",
+      "t1ProxyAdmin": "0x3e8cBA65503AeE9DAEDaa37436C7FCc0e8f3c17f",
+      "proxyImplementationPlaceholder": "0x2e22B3637f71Dc6C22c19d9F83e6E7E75B643411",
+      "t1MessengerProxy": "0xB4e41aded384620E4f8B7b9b7C4CD86118A91ca7",
+      "t1MessageQueue": "0xDf456070bF1A3B6AEdB71dEbDee3b3a7EFB4958E",
+      "t1MessengerImplementation": "0xF47811B52c09e7FB8c90eB6DDe449110c036826C",
+      "t1Owner": "0x9699Ad47112D4294dfb9482c9430B307cb7B177B",
       "t1XChainRead": {
-        "implementation": "0x8862fC66c29D06DB19f54f9202FCb4A11610279E",
-        "proxy": "0x2Ee22Dc359bb3b6Cd6442933Bb59676078c0F3d0"
+        "implementation": "0x1325732DB8AD56acC8c93D9bf06A7725646b8ED9",
+        "proxy": "0x3821b214B4c9D053fa744dc2B355E2039696dFb7"
       },
       "t1ERC7683": {
-        "implementation": "0xA9d7eF9942396d521E89ceDBa4dB4A912F567466",
-        "proxy": "0x9Ad015CfA892b21d947b73d98d3D9Cd906b88fDF"
+        "implementation": "0xfc39Ed3734F8660C96EA0523353a1CfD242e6C7d",
+        "proxy": "0xf96B8CcB029E0932fe36da0CeDd2b035E2c1695d"
       }
     },
     "deployerAddress": "0xB458Ff684cCEDb45Be3a41584B7a25fD5FCcB10F"

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -17,8 +17,7 @@
     "@hyperlane-xyz/core": "5.4.1",
     "@openzeppelin/contracts": "4.9.3",
     "@openzeppelin/contracts-upgradeable": "4.9.3",
-    "@uniswap/permit2": "github:uniswap/permit2",
-    "intents-framework": "github:BootNodeDev/intents-framework#main"
+    "@uniswap/permit2": "github:uniswap/permit2"
   },
   "devDependencies": {
     "ds-test": "github:dapphub/ds-test",

--- a/contracts/remappings.txt
+++ b/contracts/remappings.txt
@@ -1,7 +1,6 @@
 @openzeppelin/=node_modules/@openzeppelin/
 @uniswap/=node_modules/@uniswap/
 @hyperlane-xyz/=node_modules/@hyperlane-xyz/core/contracts/
-intents-framework/=node_modules/intents-framework/solidity/src/
 forge-std/=node_modules/forge-std/src/
 solmate/=node_modules/solmate/src/
 ds-test/=node_modules/ds-test/src/

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -5,13 +5,13 @@
 You can use `./deploy.sh` in the `contracts` folder to automatically deploy all the contracts. Make sure to have the
 `.env` file clean from any previous deployments.
 
-There is a particular order the deployment scripts need to be ran in. There are multiple reasons for this:
+There is a particular order the deployment scripts need to be run in. There are multiple reasons for this:
 
 - Upgradeable ProxyAdmin needs to be correct
 - Contract Owners need to be correct
 - Some L1 and L2 contracts (such as ETHGateways) need to have their target chain counterparts correctly configured
 
-Should you deploy in an incorrect order, some of the functionalities might not work correctly even if your scripts ran
+Should you deploy in an incorrect order, some of the functionalities might not work correctly even if your scripts run
 with no errors!
 
 The magical deploy order is as follows:

--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -181,13 +181,13 @@ contracts.
 #### Arbitrum Sepolia XChain Reader
 
 ```bash
-forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
+forge script ./deploy/DeployArbT1XChainReader.s.sol:DeployArbT1XChainReader --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.arbiscan.io/api --etherscan-api-key $ARBISCAN_API_KEY
 ```
 
 #### Base Sepolia XChain Reader
 
 ```bash
-forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader  --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
+forge script ./deploy/DeployBaseT1XChainReader.s.sol:DeployBaseT1XChainReader --broadcast --verify --verifier etherscan --verifier-url https://api-sepolia.basescan.org/api --etherscan-api-key $BASESCAN_API_KEY
 ```
 
 ### Deploying 7683

--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -5,8 +5,8 @@ import { Script } from "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -5,8 +5,8 @@ import { Script } from "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 

--- a/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
@@ -5,8 +5,8 @@ import { Script } from "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 

--- a/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
@@ -5,8 +5,8 @@ import { Script } from "forge-std/Script.sol";
 import { console2 } from "forge-std/console2.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 import { T1ERC7683 } from "../../../src/7683/T1ERC7683.sol";
 import { T1Constants } from "../../../src/libraries/constants/T1Constants.sol";
 

--- a/contracts/src/7683/Base7683.sol
+++ b/contracts/src/7683/Base7683.sol
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { IPermit2, ISignatureTransfer } from "@uniswap/permit2/src/interfaces/IPermit2.sol";
+
+import {
+    GaslessCrossChainOrder,
+    OnchainCrossChainOrder,
+    ResolvedCrossChainOrder,
+    IOriginSettler,
+    IDestinationSettler
+} from "../interfaces/IERC7683.sol";
+
+/**
+ * @title Base7683
+ * @notice Implements the ERC7683 standard for cross-chain order resolution, filling, settlement, and refunding.
+ * @author BootNode
+ * @dev Contains logic for managing orders without requiring specifics of the order data type.
+ * Notice that settling and refunding is not described in the ERC7683 but it is included here to provide a common
+ * interface for solvers to use.
+ */
+abstract contract Base7683 is IOriginSettler, IDestinationSettler {
+    // ============ Libraries ============
+    using SafeERC20 for IERC20;
+
+    // ============ Constants ============
+    /// @notice The instance of the Permit2 contract.
+    IPermit2 public immutable PERMIT2;
+
+    /// @notice Type hash used for encoding ResolvedCrossChainOrder.
+    bytes32 public constant RESOLVED_CROSS_CHAIN_ORDER_TYPEHASH = keccak256(
+        "ResolvedCrossChainOrder(address user, uint64 originChainId, uint32 openDeadline, uint32 fillDeadline, Output[] maxSpent, Output[] minReceived, FillInstruction[] fillInstructions)Output(bytes32 token, uint256 amount, bytes32 recipient, uint64 chainId)FillInstruction(uint64 destinationChainId, bytes32 destinationSettler, bytes originData)"
+    );
+
+    /// @notice The witness type string used in PERMIT2 transactions.
+    string public constant witnessTypeString =
+        "ResolvedCrossChainOrder witness)ResolvedCrossChainOrder(address user, uint64 originChainId, uint32 openDeadline, uint32 fillDeadline, Output[] maxSpent, Output[] minReceived, FillInstruction[] fillInstructions)Output(bytes32 token, uint256 amount, bytes32 recipient, uint64 chainId)FillInstruction(uint64 destinationChainId, bytes32 destinationSettler, bytes originData)TokenPermissions(address token,uint256 amount)";
+
+    /// @notice Possible statuses for an order. Other possible statuses should be defined in the inheriting contract.
+    bytes32 public constant UNKNOWN = "";
+    bytes32 public constant OPENED = "OPENED";
+    bytes32 public constant FILLED = "FILLED";
+
+    // ============ Structs ============
+    /**
+     * @dev Represents data for an order that has been filled.
+     * @param originData The origin-specific data for the order.
+     * @param fillerData The filler-specific data for the order.
+     */
+    struct FilledOrder {
+        bytes originData;
+        bytes fillerData;
+    }
+
+    // ============ Public Storage ============
+
+    /// @notice Tracks the used nonces for each address.
+    mapping(address => mapping(uint256 => bool)) public usedNonces;
+
+    /// @notice Stores the resolved orders by their ID.
+    mapping(bytes32 orderId => bytes orderData) public openOrders;
+
+    /// @notice Tracks filled orders and their associated data.
+    mapping(bytes32 orderId => FilledOrder filledOrder) public filledOrders;
+
+    /// @notice Tracks the status of each order by its ID.
+    mapping(bytes32 orderId => bytes32 status) public orderStatus;
+
+    // ============ Upgrade Gap ============
+    /// @dev Reserved space for future storage variables to ensure upgradeability.
+    uint256[47] private __GAP;
+
+    // ============ Events ============
+    /**
+     * @notice Emitted when an order is filled.
+     * @param orderId The ID of the filled order.
+     * @param originData The origin-specific data for the order.
+     * @param fillerData The filler-specific data for the order.
+     */
+    event Filled(bytes32 indexed orderId, bytes originData, bytes fillerData);
+
+    /**
+     * @notice Emitted when a batch of orders is settled.
+     * @param orderIds The IDs of the orders being settled.
+     * @param ordersFillerData The filler data for the settled orders.
+     */
+    event Settle(bytes32[] orderIds, bytes[] ordersFillerData);
+
+    /**
+     * @notice Emitted when a batch of orders is refunded.
+     * @param orderIds The IDs of the refunded orders.
+     */
+    event Refund(bytes32[] orderIds);
+
+    /**
+     * @notice Emitted when a nonce is invalidated for an address.
+     * @param owner The address whose nonce was invalidated.
+     * @param nonce The invalidated nonce.
+     */
+    event NonceInvalidation(address indexed owner, uint256 nonce);
+
+    // ============ Errors ============
+
+    error OrderOpenExpired();
+    error InvalidOrderStatus();
+    error InvalidGaslessOrderSettler();
+    error InvalidGaslessOrderOrigin();
+    error InvalidNonce();
+    error InvalidOrderOrigin();
+    error OrderFillNotExpired();
+    error InvalidNativeAmount();
+
+    // ============ Constructor ============
+    /**
+     * @notice Initializes the contract with the given Permit2 contract address.
+     * @param _permit2 The address of the Permit2 contract.
+     */
+    constructor(address _permit2) {
+        PERMIT2 = IPermit2(_permit2);
+    }
+
+    // ============ Initializers ============
+
+    // ============ External Functions ============
+
+    /**
+     * @notice Opens a gasless cross-chain order on behalf of a user.
+     * @dev To be called by the filler.
+     * @dev This method must emit the Open event
+     * @param _order The GaslessCrossChainOrder definition
+     * @param _signature The user's signature over the order
+     * @param _originFillerData Any filler-defined data required by the settler
+     */
+    function openFor(
+        GaslessCrossChainOrder calldata _order,
+        bytes calldata _signature,
+        bytes calldata _originFillerData
+    )
+        external
+        virtual
+    {
+        if (block.timestamp > _order.openDeadline) revert OrderOpenExpired();
+        if (_order.originSettler != address(this)) revert InvalidGaslessOrderSettler();
+        if (_order.originChainId != _localDomain()) revert InvalidGaslessOrderOrigin();
+
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) =
+            _resolveOrder(_order, _originFillerData);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(_order.user, nonce);
+
+        _permitTransferFrom(resolvedOrder, _signature, _order.nonce, address(this));
+
+        emit Open(orderId, resolvedOrder);
+    }
+
+    /**
+     * @notice Opens a cross-chain order
+     * @dev To be called by the user
+     * @dev This method must emit the Open event
+     * @param _order The OnchainCrossChainOrder definition
+     */
+    function open(OnchainCrossChainOrder calldata _order) external payable virtual {
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) = _resolveOrder(_order);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(msg.sender, nonce);
+
+        uint256 totalValue;
+        for (uint256 i = 0; i < resolvedOrder.minReceived.length; i++) {
+            address token = TypeCasts.bytes32ToAddress(resolvedOrder.minReceived[i].token);
+            if (token == address(0)) {
+                totalValue += resolvedOrder.minReceived[i].amount;
+            } else {
+                IERC20(token).safeTransferFrom(msg.sender, address(this), resolvedOrder.minReceived[i].amount);
+            }
+        }
+
+        if (msg.value != totalValue) revert InvalidNativeAmount();
+
+        emit Open(orderId, resolvedOrder);
+    }
+
+    /**
+     * @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
+     * @dev Intended to improve standardized integration of various order types and settlement contracts
+     * @param _order The GaslessCrossChainOrder definition
+     * NOT USED originFillerData Any filler-defined data required by the settler
+     * @return _resolvedOrder ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+     */
+    function resolveFor(
+        GaslessCrossChainOrder calldata _order,
+        bytes calldata _originFillerData
+    )
+        public
+        view
+        virtual
+        returns (ResolvedCrossChainOrder memory _resolvedOrder)
+    {
+        (_resolvedOrder,,) = _resolveOrder(_order, _originFillerData);
+    }
+
+    /**
+     * @notice Resolves a specific OnchainCrossChainOrder into a generic ResolvedCrossChainOrder
+     * @dev Intended to improve standardized integration of various order types and settlement contracts
+     * @param _order The OnchainCrossChainOrder definition
+     * @return _resolvedOrder ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+     */
+    function resolve(OnchainCrossChainOrder calldata _order)
+        public
+        view
+        virtual
+        returns (ResolvedCrossChainOrder memory _resolvedOrder)
+    {
+        (_resolvedOrder,,) = _resolveOrder(_order);
+    }
+
+    /**
+     * @notice Fills a single leg of a particular order on the destination chain
+     * @param _orderId Unique order identifier for this order
+     * @param _originData Data emitted on the origin to parameterize the fill
+     * @param _fillerData Data provided by the filler to inform the fill or express their preferences. It should
+     * contain the bytes32 encoded address of the receiver which is used at settlement time
+     */
+    function fill(bytes32 _orderId, bytes calldata _originData, bytes calldata _fillerData) external payable virtual {
+        if (orderStatus[_orderId] != UNKNOWN) revert InvalidOrderStatus();
+
+        _fillOrder(_orderId, _originData, _fillerData);
+
+        orderStatus[_orderId] = FILLED;
+        filledOrders[_orderId] = FilledOrder(_originData, _fillerData);
+
+        emit Filled(_orderId, _originData, _fillerData);
+    }
+
+    /**
+     * @notice Settles a batch of filled orders on the chain where the orders were opened.
+     * @dev Pays the filler the amount locked when the orders were opened.
+     * The settled status should not be changed here but rather on the origin chain. To allow the filler to retry in
+     * case some error occurs.
+     * Ensuring the order is eligible for settling in the origin chain is the responsibility of the caller.
+     * @param _orderIds An array of IDs for the orders to settle.
+     */
+    function settle(bytes32[] calldata _orderIds) external payable {
+        bytes[] memory ordersOriginData = new bytes[](_orderIds.length);
+        bytes[] memory ordersFillerData = new bytes[](_orderIds.length);
+        for (uint256 i = 0; i < _orderIds.length; i += 1) {
+            // all orders must be FILLED
+            if (orderStatus[_orderIds[i]] != FILLED) revert InvalidOrderStatus();
+
+            ordersOriginData[i] = filledOrders[_orderIds[i]].originData;
+            ordersFillerData[i] = filledOrders[_orderIds[i]].fillerData;
+        }
+
+        _settleOrders(_orderIds, ordersOriginData, ordersFillerData);
+
+        emit Settle(_orderIds, ordersFillerData);
+    }
+
+    /**
+     * @notice Refunds a batch of expired GaslessCrossChainOrders on the chain where the orders were opened.
+     * The refunded status should not be changed here but rather on the origin chain. To allow the user to retry in
+     * case some error occurs.
+     * Ensuring the order is eligible for refunding in the origin chain is the responsibility of the caller.
+     * @param _orders An array of GaslessCrossChainOrders to refund.
+     */
+    function refund(GaslessCrossChainOrder[] memory _orders) external payable {
+        bytes32[] memory orderIds = new bytes32[](_orders.length);
+        for (uint256 i = 0; i < _orders.length; i += 1) {
+            bytes32 orderId = _getOrderId(_orders[i]);
+            orderIds[i] = orderId;
+
+            if (orderStatus[orderId] != UNKNOWN) revert InvalidOrderStatus();
+            if (block.timestamp <= _orders[i].fillDeadline) revert OrderFillNotExpired();
+        }
+
+        _refundOrders(_orders, orderIds);
+
+        emit Refund(orderIds);
+    }
+
+    /**
+     * @notice Refunds a batch of expired OnchainCrossChainOrder on the chain where the orders were opened.
+     * The refunded status should not be changed here but rather on the origin chain. To allow the user to retry in
+     * case some error occurs.
+     * Ensuring the order is eligible for refunding the origin chain is the responsibility of the caller.
+     * @param _orders An array of GaslessCrossChainOrders to refund.
+     */
+    function refund(OnchainCrossChainOrder[] memory _orders) external payable {
+        bytes32[] memory orderIds = new bytes32[](_orders.length);
+        for (uint256 i = 0; i < _orders.length; i += 1) {
+            bytes32 orderId = _getOrderId(_orders[i]);
+            orderIds[i] = orderId;
+
+            if (orderStatus[orderId] != UNKNOWN) revert InvalidOrderStatus();
+            if (block.timestamp <= _orders[i].fillDeadline) revert OrderFillNotExpired();
+        }
+
+        _refundOrders(_orders, orderIds);
+
+        emit Refund(orderIds);
+    }
+
+    /**
+     * @notice Invalidates a nonce for the user calling the function.
+     * @param _nonce The nonce to invalidate.
+     */
+    function invalidateNonces(uint256 _nonce) external virtual {
+        _useNonce(msg.sender, _nonce);
+
+        emit NonceInvalidation(msg.sender, _nonce);
+    }
+
+    /**
+     * @notice Checks whether a given nonce is valid.
+     * @param _from The address whose nonce validity is being checked.
+     * @param _nonce The nonce to check.
+     * @return isValid True if the nonce is valid, false otherwise.
+     */
+    function isValidNonce(address _from, uint256 _nonce) external view virtual returns (bool) {
+        return !usedNonces[_from][_nonce];
+    }
+
+    // ============ Public Functions ============
+
+    /**
+     * @notice Computes the Permit2 witness hash for a given ResolvedCrossChainOrder.
+     * @param _resolvedOrder The ResolvedCrossChainOrder to compute the witness hash for.
+     * @return The computed witness hash.
+     */
+    function witnessHash(ResolvedCrossChainOrder memory _resolvedOrder) public pure virtual returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                RESOLVED_CROSS_CHAIN_ORDER_TYPEHASH,
+                _resolvedOrder.user,
+                _resolvedOrder.originChainId,
+                _resolvedOrder.openDeadline,
+                _resolvedOrder.fillDeadline,
+                _resolvedOrder.maxSpent,
+                _resolvedOrder.minReceived,
+                _resolvedOrder.fillInstructions
+            )
+        );
+    }
+
+    // ============ Internal Functions ============
+
+    /**
+     * @notice Marks a nonce as used by setting its bit in the appropriate bitmap.
+     * @dev Ensures that a nonce cannot be reused by flipping the corresponding bit in the bitmap.
+     * Reverts if the nonce is already used.
+     * @param _from The address for which the nonce is being used.
+     * @param _nonce The nonce to mark as used.
+     */
+    function _useNonce(address _from, uint256 _nonce) internal {
+        if (usedNonces[_from][_nonce]) revert InvalidNonce();
+        usedNonces[_from][_nonce] = true;
+    }
+
+    /**
+     * @notice Executes a batch token transfer using the Permit2 `permitWitnessTransferFrom` method.
+     * @dev Transfers tokens specified in a resolved cross-chain order to the receiver.
+     * @param _resolvedOrder The resolved order specifying tokens and amounts to transfer.
+     * @param _signature The user's signature for the permit.
+     * @param _nonce The unique nonce associated with the order.
+     * @param _receiver The address that will receive the tokens.
+     */
+    function _permitTransferFrom(
+        ResolvedCrossChainOrder memory _resolvedOrder,
+        bytes calldata _signature,
+        uint256 _nonce,
+        address _receiver
+    )
+        internal
+    {
+        ISignatureTransfer.TokenPermissions[] memory permitted =
+            new ISignatureTransfer.TokenPermissions[](_resolvedOrder.minReceived.length);
+
+        ISignatureTransfer.SignatureTransferDetails[] memory transferDetails =
+            new ISignatureTransfer.SignatureTransferDetails[](_resolvedOrder.minReceived.length);
+
+        for (uint256 i = 0; i < _resolvedOrder.minReceived.length; i++) {
+            permitted[i] = ISignatureTransfer.TokenPermissions({
+                token: TypeCasts.bytes32ToAddress(_resolvedOrder.minReceived[i].token),
+                amount: _resolvedOrder.minReceived[i].amount
+            });
+            transferDetails[i] = ISignatureTransfer.SignatureTransferDetails({
+                to: _receiver,
+                requestedAmount: _resolvedOrder.minReceived[i].amount
+            });
+        }
+
+        ISignatureTransfer.PermitBatchTransferFrom memory permit = ISignatureTransfer.PermitBatchTransferFrom({
+            permitted: permitted,
+            nonce: _nonce,
+            deadline: _resolvedOrder.openDeadline
+        });
+
+        PERMIT2.permitWitnessTransferFrom(
+            permit, transferDetails, _resolvedOrder.user, witnessHash(_resolvedOrder), witnessTypeString, _signature
+        );
+    }
+
+    /**
+     * @notice Resolves a GaslessCrossChainOrder into a ResolvedCrossChainOrder.
+     * @dev To be implemented by the inheriting contract. Contains logic specific to the order type and data.
+     * @param _order The GaslessCrossChainOrder to resolve.
+     * @param _originFillerData Any filler-defined data required by the settler
+     * @return _resolvedOrder A ResolvedCrossChainOrder with hydrated data.
+     * @return _orderId The unique identifier for the order.
+     * @return _nonce The nonce associated with the order.
+     */
+    function _resolveOrder(
+        GaslessCrossChainOrder memory _order,
+        bytes calldata _originFillerData
+    )
+        internal
+        view
+        virtual
+        returns (ResolvedCrossChainOrder memory _resolvedOrder, bytes32 _orderId, uint256 _nonce);
+
+    /**
+     * @notice Resolves an OnchainCrossChainOrder into a ResolvedCrossChainOrder.
+     * @dev To be implemented by the inheriting contract. Contains logic specific to the order type and data.
+     * @param _order The OnchainCrossChainOrder to resolve.
+     * @return _resolvedOrder A ResolvedCrossChainOrder with hydrated data.
+     * @return _orderId The unique identifier for the order.
+     * @return _nonce The nonce associated with the order.
+     */
+    function _resolveOrder(OnchainCrossChainOrder memory _order)
+        internal
+        view
+        virtual
+        returns (ResolvedCrossChainOrder memory _resolvedOrder, bytes32 _orderId, uint256 _nonce);
+
+    /**
+     * @notice Fills an order with specific origin and filler data.
+     * @dev To be implemented by the inheriting contract. Defines how to process the origin and filler data.
+     * @param _orderId The unique identifier for the order to fill.
+     * @param _originData Data emitted on the origin chain to parameterize the fill.
+     * @param _fillerData Data provided by the filler, including preferences and additional information.
+     */
+    function _fillOrder(bytes32 _orderId, bytes calldata _originData, bytes calldata _fillerData) internal virtual;
+
+    /**
+     * @notice Settles a batch of orders using their origin and filler data.
+     * @dev To be implemented by the inheriting contract. Contains the specific logic for settlement.
+     * @param _orderIds An array of order IDs to settle.
+     * @param _ordersOriginData The origin data for the orders being settled.
+     * @param _ordersFillerData The filler data for the orders being settled.
+     */
+    function _settleOrders(
+        bytes32[] calldata _orderIds,
+        bytes[] memory _ordersOriginData,
+        bytes[] memory _ordersFillerData
+    )
+        internal
+        virtual;
+
+    /**
+     * @notice Refunds a batch of OnchainCrossChainOrders.
+     * @dev To be implemented by the inheriting contract. Contains logic specific to refunds.
+     * @param _orders An array of OnchainCrossChainOrders to refund.
+     * @param _orderIds An array of IDs for the orders to refund.
+     */
+    function _refundOrders(OnchainCrossChainOrder[] memory _orders, bytes32[] memory _orderIds) internal virtual;
+
+    /**
+     * @notice Refunds a batch of GaslessCrossChainOrders.
+     * @dev To be implemented by the inheriting contract. Contains logic specific to refunds.
+     * @param _orders An array of GaslessCrossChainOrders to refund.
+     * @param _orderIds An array of IDs for the orders to refund.
+     */
+    function _refundOrders(GaslessCrossChainOrder[] memory _orders, bytes32[] memory _orderIds) internal virtual;
+
+    /**
+     * @notice Retrieves the local domain identifier.
+     * @dev To be implemented by the inheriting contract. Specifies the logic to determine the local domain.
+     * @return The local domain ID.
+     */
+    function _localDomain() internal view virtual returns (uint32);
+
+    /**
+     * @notice Computes the unique identifier for a GaslessCrossChainOrder.
+     * @dev To be implemented by the inheriting contract. Specifies the logic to compute the order ID.
+     * @param _order The GaslessCrossChainOrder to compute the ID for.
+     * @return The unique identifier for the order.
+     */
+    function _getOrderId(GaslessCrossChainOrder memory _order) internal pure virtual returns (bytes32);
+
+    /**
+     * @notice Computes the unique identifier for an OnchainCrossChainOrder.
+     * @dev To be implemented by the inheriting contract. Specifies the logic to compute the order ID.
+     * @param _order The OnchainCrossChainOrder to compute the ID for.
+     * @return The unique identifier for the order.
+     */
+    function _getOrderId(OnchainCrossChainOrder memory _order) internal pure virtual returns (bytes32);
+}

--- a/contracts/src/7683/BasicSwap7683.sol
+++ b/contracts/src/7683/BasicSwap7683.sol
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+
+import { Base7683 } from "./Base7683.sol";
+import { OrderData, OrderEncoder } from "../libraries/7683/OrderEncoder.sol";
+
+import {
+    GaslessCrossChainOrder,
+    OnchainCrossChainOrder,
+    ResolvedCrossChainOrder,
+    Output,
+    FillInstruction,
+    IOriginSettler,
+    IDestinationSettler
+} from "../interfaces/IERC7683.sol";
+
+/**
+ * @title BasicSwap7683
+ * @author BootNode
+ * @notice This contract builds on top of Base7683 as a second layer, implementing logic to handle a specific type of
+ * order for swapping a single token.
+ * @dev This is an abstract contract intended to be inherited by a third contract that will function as the messaging
+ * layer.
+ */
+abstract contract BasicSwap7683 is Base7683 {
+    // ============ Libraries ============
+    using SafeERC20 for IERC20;
+
+    // ============ Constants ============
+    /// @notice Status constant indicating that an order has been settled.
+    bytes32 public constant SETTLED = "SETTLED";
+    /// @notice Status constant indicating that an order has been refunded.
+    bytes32 public constant REFUNDED = "REFUNDED";
+
+    // ============ Public Storage ============
+
+    // ============ Upgrade Gap ============
+    /// @dev Reserved storage slots for upgradeability.
+    uint256[47] private __GAP;
+
+    // ============ Events ============
+    /**
+     * @notice Emitted when an order is settled.
+     * @param orderId The ID of the settled order.
+     * @param receiver The address of the order's input token receiver.
+     */
+    event Settled(bytes32 indexed orderId, address receiver);
+
+    /**
+     * @notice Emitted when an order is refunded.
+     * @param orderId The ID of the refunded order.
+     * @param receiver The address of the order's input token receiver.
+     */
+    event Refunded(bytes32 indexed orderId, address receiver);
+
+    // ============ Errors ============
+
+    error InvalidOrderType(bytes32 orderType);
+    error InvalidOriginDomain(uint32 originDomain);
+    error InvalidOrderId();
+    error OrderFillExpired();
+    error InvalidOrderDomain();
+    error InvalidDomain();
+    error InvalidSender();
+
+    // ============ Modifiers ============
+
+    // ============ Constructor ============
+    /**
+     * @dev Initializes the contract by calling the constructor of Base7683 with the permit2 address.
+     * @param _permit2 The address of the PERMIT2 contract.
+     */
+    constructor(address _permit2) Base7683(_permit2) { }
+
+    // ============ Initializers ============
+
+    // ============ External Functions ============
+
+    // ============ Internal Functions ============
+
+    /**
+     * @dev Settles multiple orders by dispatching the settlement instructions.
+     * The proper status of all the orders (filled) is validated on the Base7683 before calling this function.
+     * It assumes that all orders were originated in the same originDomain so it uses the the one from the first one for
+     * dispatching the message, but if some order differs on the originDomain it can be re-settle later.
+     * @param _orderIds The IDs of the orders to settle.
+     * @param _ordersOriginData The original data of the orders.
+     * @param _ordersFillerData The filler data for the orders.
+     */
+    function _settleOrders(
+        bytes32[] calldata _orderIds,
+        bytes[] memory _ordersOriginData,
+        bytes[] memory _ordersFillerData
+    )
+        internal
+        override
+    {
+        // at this point we are sure all orders are filled, use the first order to get the originDomain
+        // if some order differs on the originDomain it can be re-settle later
+        _dispatchSettle(OrderEncoder.decode(_ordersOriginData[0]).originDomain, _orderIds, _ordersFillerData);
+    }
+
+    /**
+     * @dev Refunds multiple OnchainCrossChain orders by dispatching refund instructions.
+     * The proper status of all the orders (NOT filled and expired) is validated on the Base7683 before calling this
+     * function.
+     * It assumes that all orders were originated in the same originDomain so it uses the the one from the first one for
+     * dispatching the message, but if some order differs on the originDomain it can be re-refunded later.
+     * @param _orders The orders to refund.
+     * @param _orderIds The IDs of the orders to refund.
+     */
+    function _refundOrders(OnchainCrossChainOrder[] memory _orders, bytes32[] memory _orderIds) internal override {
+        _dispatchRefund(OrderEncoder.decode(_orders[0].orderData).originDomain, _orderIds);
+    }
+
+    /**
+     * @dev Refunds multiple GaslessCrossChain orders by dispatching refund instructions.
+     * The proper status of all the orders (NOT filled and expired) is validated on the Base7683 before calling this
+     * function.
+     * It assumes that all orders were originated in the same originDomain so it uses the the one from the first one for
+     * dispatching the message, but if some order differs on the originDomain it can be re-refunded later.
+     * @param _orders The orders to refund.
+     * @param _orderIds The IDs of the orders to refund.
+     */
+    function _refundOrders(GaslessCrossChainOrder[] memory _orders, bytes32[] memory _orderIds) internal override {
+        _dispatchRefund(OrderEncoder.decode(_orders[0].orderData).originDomain, _orderIds);
+    }
+
+    /**
+     * @dev Handles settling an individual order, should be called by the inheriting contract when receiving a setting
+     * instruction from a remote chain.
+     * @param _messageOrigin The domain from which the message originates.
+     * @param _messageSender The address of the sender on the origin domain.
+     * @param _orderId The ID of the order to settle.
+     * @param _receiver The receiver address (encoded as bytes32).
+     */
+    function _handleSettleOrder(
+        uint32 _messageOrigin,
+        bytes32 _messageSender,
+        bytes32 _orderId,
+        bytes32 _receiver
+    )
+        internal
+        virtual
+    {
+        (bool isEligible, OrderData memory orderData) = _checkOrderEligibility(_messageOrigin, _messageSender, _orderId);
+
+        if (!isEligible) return;
+
+        orderStatus[_orderId] = SETTLED;
+
+        address receiver = TypeCasts.bytes32ToAddress(_receiver);
+        address inputToken = TypeCasts.bytes32ToAddress(orderData.inputToken);
+
+        _transferTokenOut(inputToken, receiver, orderData.amountIn);
+
+        emit Settled(_orderId, receiver);
+    }
+
+    /**
+     * @dev Handles refunding an individual order, should be called by the inheriting contract when receiving a
+     * refunding instruction from a remote chain.
+     * @param _messageOrigin The domain from which the message originates.
+     * @param _messageSender The address of the sender on the origin domain.
+     * @param _orderId The ID of the order to refund.
+     */
+    function _handleRefundOrder(uint32 _messageOrigin, bytes32 _messageSender, bytes32 _orderId) internal virtual {
+        (bool isEligible, OrderData memory orderData) = _checkOrderEligibility(_messageOrigin, _messageSender, _orderId);
+
+        if (!isEligible) return;
+
+        orderStatus[_orderId] = REFUNDED;
+
+        address orderSender = TypeCasts.bytes32ToAddress(orderData.sender);
+        address inputToken = TypeCasts.bytes32ToAddress(orderData.inputToken);
+
+        _transferTokenOut(inputToken, orderSender, orderData.amountIn);
+
+        emit Refunded(_orderId, orderSender);
+    }
+
+    /**
+     * @notice Checks if order is eligible for settlement or refund .
+     * @dev Order must be OPENED and the message was sent from the appropriated chain and contract.
+     * @param _messageOrigin The origin domain of the message.
+     * @param _messageSender The sender identifier of the message.
+     * @param _orderId The unique identifier of the order.
+     * @return A boolean indicating if the order is valid, and the decoded OrderData structure.
+     */
+    function _checkOrderEligibility(
+        uint32 _messageOrigin,
+        bytes32 _messageSender,
+        bytes32 _orderId
+    )
+        internal
+        virtual
+        returns (bool, OrderData memory)
+    {
+        OrderData memory orderData;
+
+        // check if the order is opened to ensure it belongs to this domain, skip otherwise
+        if (orderStatus[_orderId] != OPENED) return (false, orderData);
+
+        (, bytes memory _orderData) = abi.decode(openOrders[_orderId], (bytes32, bytes));
+        orderData = OrderEncoder.decode(_orderData);
+
+        if (orderData.destinationDomain != _messageOrigin || orderData.destinationSettler != _messageSender) {
+            return (false, orderData);
+        }
+
+        return (true, orderData);
+    }
+
+    /**
+     * @notice Transfers tokens or ETH out of the contract.
+     * @dev If _token is the zero address, transfers ETH using a safe method; otherwise, performs an ERC20 token
+     * transfer.
+     * @param _token The address of the token to transfer (use address(0) for ETH).
+     * @param _to The recipient address.
+     * @param _amount The amount of tokens or ETH to transfer.
+     */
+    function _transferTokenOut(address _token, address _to, uint256 _amount) internal {
+        if (_token == address(0)) {
+            Address.sendValue(payable(_to), _amount);
+        } else {
+            IERC20(_token).safeTransfer(_to, _amount);
+        }
+    }
+
+    /**
+     * @dev Gets the ID of a GaslessCrossChainOrder.
+     * @param _order The GaslessCrossChainOrder to compute the ID for.
+     * @return The computed order ID.
+     */
+    function _getOrderId(GaslessCrossChainOrder memory _order) internal pure override returns (bytes32) {
+        return _getOrderId(_order.orderDataType, _order.orderData);
+    }
+
+    /**
+     * @dev Gets the ID of an OnchainCrossChainOrder.
+     * @param _order The OnchainCrossChainOrder to compute the ID for.
+     * @return The computed order ID.
+     */
+    function _getOrderId(OnchainCrossChainOrder memory _order) internal pure override returns (bytes32) {
+        return _getOrderId(_order.orderDataType, _order.orderData);
+    }
+
+    /**
+     * @dev Computes the ID of an order given its type and data.
+     * @param _orderType The type of the order.
+     * @param _orderData The data of the order.
+     * @return orderId The computed order ID.
+     */
+    function _getOrderId(bytes32 _orderType, bytes memory _orderData) internal pure returns (bytes32 orderId) {
+        if (_orderType != OrderEncoder.orderDataType()) revert InvalidOrderType(_orderType);
+        OrderData memory orderData = OrderEncoder.decode(_orderData);
+        orderId = OrderEncoder.id(orderData);
+    }
+
+    /**
+     * @dev Resolves a GaslessCrossChainOrder.
+     * @param _order The GaslessCrossChainOrder to resolve.
+     * NOT USED _originFillerData Any filler-defined data required by the settler
+     * @return A ResolvedCrossChainOrder structure.
+     * @return The order ID.
+     * @return The order nonce.
+     */
+    function _resolveOrder(
+        GaslessCrossChainOrder memory _order,
+        bytes calldata
+    )
+        internal
+        view
+        virtual
+        override
+        returns (ResolvedCrossChainOrder memory, bytes32, uint256)
+    {
+        return _resolvedOrder(
+            _order.orderDataType, _order.user, _order.openDeadline, _order.fillDeadline, _order.orderData
+        );
+    }
+
+    /**
+     * @notice Resolves a OnchainCrossChainOrder.
+     * @param _order The OnchainCrossChainOrder to resolve.
+     * @return A ResolvedCrossChainOrder structure.
+     * @return The order ID.
+     * @return The order nonce.
+     */
+    function _resolveOrder(OnchainCrossChainOrder memory _order)
+        internal
+        view
+        virtual
+        override
+        returns (ResolvedCrossChainOrder memory, bytes32, uint256)
+    {
+        return _resolvedOrder(_order.orderDataType, msg.sender, type(uint32).max, _order.fillDeadline, _order.orderData);
+    }
+
+    /**
+     * @dev Resolves an order into a ResolvedCrossChainOrder structure.
+     * @param _orderType The type of the order.
+     * @param _sender The sender of the order.
+     * @param _openDeadline The open deadline of the order.
+     * @param _fillDeadline The fill deadline of the order.
+     * @param _orderData The data of the order.
+     * @return resolvedOrder A ResolvedCrossChainOrder structure.
+     * @return orderId The order ID.
+     * @return nonce The order nonce.
+     */
+    function _resolvedOrder(
+        bytes32 _orderType,
+        address _sender,
+        uint32 _openDeadline,
+        uint32 _fillDeadline,
+        bytes memory _orderData
+    )
+        internal
+        view
+        returns (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce)
+    {
+        if (_orderType != OrderEncoder.orderDataType()) revert InvalidOrderType(_orderType);
+
+        // IDEA: _orderData should not be directly typed as OrderData, it should contain information that is not
+        // present on the type used for open the order. So _fillDeadline and _user should be passed as arguments
+        OrderData memory orderData = OrderEncoder.decode(_orderData);
+
+        if (orderData.originDomain != _localDomain()) revert InvalidOriginDomain(orderData.originDomain);
+
+        // bytes32 destinationSettler = _mustHaveRemoteCounterpart(orderData.destinationDomain);
+
+        // enforce fillDeadline into orderData
+        orderData.fillDeadline = _fillDeadline;
+        // enforce sender into orderData
+        orderData.sender = TypeCasts.addressToBytes32(_sender);
+
+        // this can be used by the filler to approve the tokens to be spent on destination
+        Output[] memory maxSpent = new Output[](1);
+        maxSpent[0] = Output({
+            token: orderData.outputToken,
+            amount: orderData.amountOut,
+            recipient: orderData.destinationSettler,
+            chainId: orderData.destinationDomain
+        });
+
+        // this can be used by the filler know how much it can expect to receive
+        Output[] memory minReceived = new Output[](1);
+        minReceived[0] = Output({
+            token: orderData.inputToken,
+            amount: orderData.amountIn,
+            recipient: bytes32(0),
+            chainId: orderData.originDomain
+        });
+
+        // this can be user by the filler to know how to fill the order
+        FillInstruction[] memory fillInstructions = new FillInstruction[](1);
+        fillInstructions[0] = FillInstruction({
+            destinationChainId: orderData.destinationDomain,
+            destinationSettler: orderData.destinationSettler,
+            originData: OrderEncoder.encode(orderData)
+        });
+
+        orderId = OrderEncoder.id(orderData);
+
+        resolvedOrder = ResolvedCrossChainOrder({
+            user: _sender,
+            originChainId: _localDomain(),
+            openDeadline: _openDeadline,
+            fillDeadline: _fillDeadline,
+            orderId: orderId,
+            minReceived: minReceived,
+            maxSpent: maxSpent,
+            fillInstructions: fillInstructions
+        });
+
+        nonce = orderData.senderNonce;
+    }
+
+    /**
+     * @dev Fills an order on the current domain.
+     * @param _orderId The ID of the order to fill.
+     * @param _originData The origin data of the order.
+     * Additional data related to the order (unused).
+     */
+    function _fillOrder(bytes32 _orderId, bytes calldata _originData, bytes calldata) internal override {
+        OrderData memory orderData = OrderEncoder.decode(_originData);
+
+        if (_orderId != OrderEncoder.id(orderData)) revert InvalidOrderId();
+        if (block.timestamp > orderData.fillDeadline) revert OrderFillExpired();
+        if (orderData.destinationDomain != _localDomain()) revert InvalidOrderDomain();
+
+        address outputToken = TypeCasts.bytes32ToAddress(orderData.outputToken);
+        address recipient = TypeCasts.bytes32ToAddress(orderData.recipient);
+
+        if (outputToken == address(0)) {
+            if (orderData.amountOut != msg.value) revert InvalidNativeAmount();
+            Address.sendValue(payable(recipient), orderData.amountOut);
+        } else {
+            IERC20(outputToken).safeTransferFrom(msg.sender, recipient, orderData.amountOut);
+        }
+    }
+
+    /**
+     * @dev Should be implemented by the messaging layer for dispatching a settlement instruction the remote domain
+     * where the orders where created.
+     * @param _originDomain The origin domain of the orders.
+     * @param _orderIds The IDs of the orders to settle.
+     * @param _ordersFillerData The filler data for the orders.
+     */
+    function _dispatchSettle(
+        uint32 _originDomain,
+        bytes32[] memory _orderIds,
+        bytes[] memory _ordersFillerData
+    )
+        internal
+        virtual;
+
+    /**
+     * @dev Should be implemented by the messaging layer for dispatching a refunding instruction the remote domain
+     * where the orders where created.
+     * @param _originDomain The origin domain of the orders.
+     * @param _orderIds The IDs of the orders to refund.
+     */
+    function _dispatchRefund(uint32 _originDomain, bytes32[] memory _orderIds) internal virtual;
+}

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -2,19 +2,26 @@
 pragma solidity ^0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import { Hyperlane7683Message } from "../libraries/7683/Hyperlane7683Message.sol";
-import { BasicSwap7683 } from "./BasicSwap7683.sol";
-import { OrderData, OrderEncoder } from "../libraries/7683/OrderEncoder.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
+import { GaslessCrossChainOrder, ResolvedCrossChainOrder, OnchainCrossChainOrder } from "../interfaces/IERC7683.sol";
+import { BasicSwap7683 } from "./BasicSwap7683.sol";
+import { Hyperlane7683Message } from "../libraries/7683/Hyperlane7683Message.sol";
+import { OrderData, OrderEncoder } from "../libraries/7683/OrderEncoder.sol";
 import { T1XChainReader } from "../libraries/xChain/T1XChainReader.sol";
+
 /**
  * @title T1ERC7683
  * @author t1 Labs
  * @notice This contract extends BasicSwap7683 with pull-based settlement using t1 cross-chain reads
  * @dev Implements both push-based messaging and pull-based verification for orders
  */
+contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
+    using SafeERC20 for IERC20;
 
-contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     // ============ Constants ============
     uint32 public immutable localDomain;
     T1XChainReader public immutable xChainRead;
@@ -47,7 +54,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
 
     // ============ Errors ============
     error FunctionNotImplemented(string functionName);
-    error EthNotAllowed();
     error SettlementFailed();
     error RefundFailed();
 
@@ -67,6 +73,54 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     function initialize(address _counterpart) external initializer {
         counterpart = _counterpart;
         __Ownable_init();
+        __Pausable_init();
+    }
+
+    function open(OnchainCrossChainOrder calldata _order) external payable override whenNotPaused {
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) = _resolveOrder(_order);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(msg.sender, nonce);
+
+        uint256 totalValue;
+        for (uint256 i = 0; i < resolvedOrder.minReceived.length; i++) {
+            address token = TypeCasts.bytes32ToAddress(resolvedOrder.minReceived[i].token);
+            if (token == address(0)) {
+                totalValue += resolvedOrder.minReceived[i].amount;
+            } else {
+                IERC20(token).safeTransferFrom(msg.sender, address(this), resolvedOrder.minReceived[i].amount);
+            }
+        }
+
+        if (msg.value != totalValue) revert InvalidNativeAmount();
+
+        emit Open(orderId, resolvedOrder);
+    }
+
+    function openFor(
+        GaslessCrossChainOrder calldata _order,
+        bytes calldata _signature,
+        bytes calldata _originFillerData
+    )
+        external
+        override
+        whenNotPaused
+    {
+        if (block.timestamp > _order.openDeadline) revert OrderOpenExpired();
+        if (_order.originSettler != address(this)) revert InvalidGaslessOrderSettler();
+        if (_order.originChainId != _localDomain()) revert InvalidGaslessOrderOrigin();
+
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) =
+            _resolveOrder(_order, _originFillerData);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(_order.user, nonce);
+
+        _permitTransferFrom(resolvedOrder, _signature, _order.nonce, address(this));
+
+        emit Open(orderId, resolvedOrder);
     }
 
     /// @notice Initiates a pull-based settlement verification for an order
@@ -134,6 +188,14 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
         }
 
         emit SettlementVerified(orderId, isSettled);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     function getFilledOrderStatus(bytes32 orderId) external view returns (bytes memory) {

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -111,7 +111,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
     function handleReadResultWithProof(bytes calldata encodedProofOfRead) external {
         (bytes32 requestId, bytes memory result) = xChainRead.verifyProofOfRead(encodedProofOfRead);
-
+        
         bytes32 orderId = readRequestToOrderId[requestId];
 
         // Ensure we have a valid order
@@ -168,8 +168,10 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// @param _sender The address of the sender on the origin domain
     /// @param _message The encoded message received via t1
     function _handle(uint32 _originDomain, bytes32 _sender, bytes memory _message) internal {
+        // Remove the first 32 bytes prefix of the message
+        bytes memory _innerMessage = abi.decode(_message, (bytes));
         (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
-            abi.decode(_message, (bool, bytes32[], bytes[]));
+            abi.decode(_innerMessage, (bool, bytes32[], bytes[]));
 
         for (uint256 i = 0; i < _orderIds.length; i++) {
             if (_settle) {

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -149,7 +149,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
             gasLimit: gasLimit,
             minBlock: 0,
             callData: callData,
-            requester: _msgSender()
+            requester: msg.sender
         });
 
         // Request the cross-chain read

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -111,7 +111,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     /// abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
     function handleReadResultWithProof(bytes calldata encodedProofOfRead) external {
         (bytes32 requestId, bytes memory result) = xChainRead.verifyProofOfRead(encodedProofOfRead);
-        
+
         bytes32 orderId = readRequestToOrderId[requestId];
 
         // Ensure we have a valid order

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -94,7 +94,8 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
             targetContract: counterpart,
             gasLimit: gasLimit,
             minBlock: 0,
-            callData: callData
+            callData: callData,
+            requester: _msgSender()
         });
 
         // Request the cross-chain read

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
-import { Hyperlane7683Message } from "intents-framework/libs/Hyperlane7683Message.sol";
-import { BasicSwap7683 } from "intents-framework/BasicSwap7683.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
+import { Hyperlane7683Message } from "../libraries/7683/Hyperlane7683Message.sol";
+import { BasicSwap7683 } from "./BasicSwap7683.sol";
+import { OrderData, OrderEncoder } from "../libraries/7683/OrderEncoder.sol";
 
 import { T1XChainReader } from "../libraries/xChain/T1XChainReader.sol";
 /**

--- a/contracts/src/interfaces/IERC7683.sol
+++ b/contracts/src/interfaces/IERC7683.sol
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.25;
+
+/// @title GaslessCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct to be signed by users, disseminated to fillers, and submitted to origin settler
+/// contracts by fillers
+struct GaslessCrossChainOrder {
+    /// @dev The contract address that the order is meant to be settled by.
+    /// Fillers send this order to this contract address on the origin chain
+    address originSettler;
+    /// @dev The address of the user who is initiating the swap,
+    /// whose input tokens will be taken and escrowed
+    address user;
+    /// @dev Nonce to be used as replay protection for the order
+    uint256 nonce;
+    /// @dev The chainId of the origin chain
+    uint256 originChainId;
+    /// @dev The timestamp by which the order must be opened
+    uint32 openDeadline;
+    /// @dev The timestamp by which the order must be filled on the destination chain
+    uint32 fillDeadline;
+    /// @dev Type identifier for the order data. This is an EIP-712 typehash.
+    bytes32 orderDataType;
+    /// @dev Arbitrary implementation-specific data
+    /// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
+    /// or any other order-type specific information
+    bytes orderData;
+}
+
+/// @title OnchainCrossChainOrder CrossChainOrder type
+/// @notice Standard order struct for user-opened orders, where the user is the one submitting the order creation
+/// transaction
+struct OnchainCrossChainOrder {
+    /// @dev The timestamp by which the order must be filled on the destination chain
+    uint32 fillDeadline;
+    /// @dev Type identifier for the order data. This is an EIP-712 typehash.
+    bytes32 orderDataType;
+    /// @dev Arbitrary implementation-specific data
+    /// Can be used to define tokens, amounts, destination chains, fees, settlement parameters,
+    /// or any other order-type specific information
+    bytes orderData;
+}
+
+/// @title ResolvedCrossChainOrder type
+/// @notice An implementation-generic representation of an order intended for filler consumption
+/// @dev Defines all requirements for filling an order by unbundling the implementation-specific orderData.
+/// @dev Intended to improve integration generalization by allowing fillers to compute the exact input and output
+/// information of any order
+struct ResolvedCrossChainOrder {
+    /// @dev The address of the user who is initiating the transfer
+    address user;
+    /// @dev The chainId of the origin chain
+    uint256 originChainId;
+    /// @dev The timestamp by which the order must be opened
+    uint32 openDeadline;
+    /// @dev The timestamp by which the order must be filled on the destination chain(s)
+    uint32 fillDeadline;
+    /// @dev The unique identifier for this order within this settlement system
+    bytes32 orderId;
+    /// @dev The max outputs that the filler will send. It's possible the actual amount depends on the state of the
+    /// destination
+    ///      chain (destination dutch auction, for instance), so these outputs should be considered a cap on filler
+    /// liabilities.
+    Output[] maxSpent;
+    /// @dev The minimum outputs that must be given to the filler as part of order settlement. Similar to maxSpent, it's
+    /// possible
+    ///      that special order types may not be able to guarantee the exact amount at open time, so this should be
+    /// considered
+    ///      a floor on filler receipts. Setting the `recipient` of an `Output` to address(0) indicates that the filler
+    /// is not
+    ///      known when creating this order.
+    Output[] minReceived;
+    /// @dev Each instruction in this array is parameterizes a single leg of the fill. This provides the filler with the
+    /// information
+    ///      necessary to perform the fill on the destination(s).
+    FillInstruction[] fillInstructions;
+}
+
+/// @notice Tokens that must be received for a valid order fulfillment
+struct Output {
+    /// @dev The address of the ERC20 token on the destination chain
+    /// @dev address(0) used as a sentinel for the native token
+    bytes32 token;
+    /// @dev The amount of the token to be sent
+    uint256 amount;
+    /// @dev The address to receive the output tokens
+    bytes32 recipient;
+    /// @dev The destination chain for this output
+    uint256 chainId;
+}
+
+/// @title FillInstruction type
+/// @notice Instructions to parameterize each leg of the fill
+/// @dev Provides all the origin-generated information required to produce a valid fill leg
+struct FillInstruction {
+    /// @dev The chain that this instruction is intended to be filled on
+    uint256 destinationChainId;
+    /// @dev The contract address that the instruction is intended to be filled on
+    bytes32 destinationSettler;
+    /// @dev The data generated on the origin chain needed by the destinationSettler to process the fill
+    bytes originData;
+}
+
+/// @title IOriginSettler
+/// @notice Standard interface for settlement contracts on the origin chain
+interface IOriginSettler {
+    /// @notice Signals that an order has been opened
+    /// @param orderId a unique order identifier within this settlement system
+    /// @param resolvedOrder resolved order that would be returned by resolve if called instead of Open
+    event Open(bytes32 indexed orderId, ResolvedCrossChainOrder resolvedOrder);
+
+    /// @notice Opens a gasless cross-chain order on behalf of a user.
+    /// @dev To be called by the filler.
+    /// @dev This method must emit the Open event
+    /// @param order The GaslessCrossChainOrder definition
+    /// @param signature The user's signature over the order
+    /// @param originFillerData Any filler-defined data required by the settler
+    function openFor(
+        GaslessCrossChainOrder calldata order,
+        bytes calldata signature,
+        bytes calldata originFillerData
+    )
+        external;
+
+    /// @notice Opens a cross-chain order
+    /// @dev To be called by the user
+    /// @dev This method must emit the Open event
+    /// @param order The OnchainCrossChainOrder definition
+    function open(OnchainCrossChainOrder calldata order) external payable;
+
+    /// @notice Resolves a specific GaslessCrossChainOrder into a generic ResolvedCrossChainOrder
+    /// @dev Intended to improve standardized integration of various order types and settlement contracts
+    /// @param order The GaslessCrossChainOrder definition
+    /// @param originFillerData Any filler-defined data required by the settler
+    /// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+    function resolveFor(
+        GaslessCrossChainOrder calldata order,
+        bytes calldata originFillerData
+    )
+        external
+        view
+        returns (ResolvedCrossChainOrder memory);
+
+    /// @notice Resolves a specific OnchainCrossChainOrder into a generic ResolvedCrossChainOrder
+    /// @dev Intended to improve standardized integration of various order types and settlement contracts
+    /// @param order The OnchainCrossChainOrder definition
+    /// @return ResolvedCrossChainOrder hydrated order data including the inputs and outputs of the order
+    function resolve(OnchainCrossChainOrder calldata order) external view returns (ResolvedCrossChainOrder memory);
+}
+
+/// @title IDestinationSettler
+/// @notice Standard interface for settlement contracts on the destination chain
+interface IDestinationSettler {
+    /// @notice Fills a single leg of a particular order on the destination chain
+    /// @param orderId Unique order identifier for this order
+    /// @param originData Data emitted on the origin to parameterize the fill
+    /// @param fillerData Data provided by the filler to inform the fill or express their preferences
+    function fill(bytes32 orderId, bytes calldata originData, bytes calldata fillerData) external payable;
+}

--- a/contracts/src/libraries/7683/Hyperlane7683Message.sol
+++ b/contracts/src/libraries/7683/Hyperlane7683Message.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.25;
+
+// ============ External Imports ============
+
+library Hyperlane7683Message {
+    /**
+     * @notice Returns formatted Router7683 message
+     * @dev This function should only be used in memory message construction.
+     * @param _settle Flag to indicate if the message is a settlement or refund
+     * @param _orderIds The orderIds to settle or refund
+     * @param _ordersFillerData Each element should contain the bytes32 encoded address of the settlement receiver.
+     * @return Formatted message body
+     */
+    function encode(
+        bool _settle,
+        bytes32[] memory _orderIds,
+        bytes[] memory _ordersFillerData
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(_settle, _orderIds, _ordersFillerData);
+    }
+
+    /**
+     * @notice Parses and returns the calls from the provided message
+     * @param _message The interchain message
+     * @return The array of calls
+     */
+    function decode(bytes calldata _message) internal pure returns (bool, bytes32[] memory, bytes[] memory) {
+        return abi.decode(_message, (bool, bytes32[], bytes[]));
+    }
+
+    function encodeSettle(
+        bytes32[] memory _orderIds,
+        bytes[] memory _ordersFillerData
+    )
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return encode(true, _orderIds, _ordersFillerData);
+    }
+
+    function encodeRefund(bytes32[] memory _orderIds) internal pure returns (bytes memory) {
+        return encode(false, _orderIds, new bytes[](0));
+    }
+}

--- a/contracts/src/libraries/7683/OrderEncoder.sol
+++ b/contracts/src/libraries/7683/OrderEncoder.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.25;
+
+struct OrderData {
+    bytes32 sender;
+    bytes32 recipient;
+    bytes32 inputToken;
+    bytes32 outputToken;
+    uint256 amountIn;
+    uint256 amountOut;
+    uint256 senderNonce;
+    uint32 originDomain;
+    uint32 destinationDomain;
+    bytes32 destinationSettler;
+    uint32 fillDeadline;
+    bytes data;
+}
+
+library OrderEncoder {
+    bytes constant ORDER_DATA_TYPE = abi.encodePacked(
+        "OrderData(",
+        "bytes32 sender,",
+        "bytes32 recipient,",
+        "bytes32 inputToken,",
+        "bytes32 outputToken,",
+        "uint256 amountIn,",
+        "uint256 amountOut,",
+        "uint256 senderNonce,",
+        "uint32 originDomain,",
+        "uint32 destinationDomain,",
+        "bytes32 destinationSettler,",
+        "uint32 fillDeadline,",
+        "bytes data)"
+    );
+
+    bytes32 constant ORDER_DATA_TYPE_HASH = keccak256(ORDER_DATA_TYPE);
+
+    function orderDataType() internal pure returns (bytes32) {
+        return ORDER_DATA_TYPE_HASH;
+    }
+
+    function id(OrderData memory order) internal pure returns (bytes32) {
+        return keccak256(encode(order));
+    }
+
+    function encode(OrderData memory order) internal pure returns (bytes memory) {
+        return abi.encode(order);
+    }
+
+    function decode(bytes memory orderBytes) internal pure returns (OrderData memory) {
+        (OrderData memory orderData) = abi.decode(orderBytes, (OrderData));
+
+        return orderData;
+    }
+}

--- a/contracts/src/libraries/xChain/T1XChainMessage.sol
+++ b/contracts/src/libraries/xChain/T1XChainMessage.sol
@@ -18,12 +18,13 @@ library T1XChainMessage {
         uint32 originDomain,
         bytes32 sender,
         bytes32 requestId,
-        bytes memory callData
+        bytes memory callData,
+        address requester
     )
         internal
         pure
         returns (bytes memory)
     {
-        return abi.encode(originDomain, sender, requestId, callData);
+        return abi.encode(originDomain, sender, requestId, callData, requester);
     }
 }

--- a/contracts/src/libraries/xChain/T1XChainReader.sol
+++ b/contracts/src/libraries/xChain/T1XChainReader.sol
@@ -104,7 +104,7 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      */
     function requestRead(ReadRequest calldata request) external payable nonReentrant returns (bytes32 requestId) {
         return _processReadRequest(
-            request.destinationDomain, request.targetContract, request.gasLimit, request.minBlock, request.callData
+            request.destinationDomain, request.targetContract, request.gasLimit, request.minBlock, request.callData, request.requester
         );
     }
 
@@ -113,21 +113,22 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         address targetContract,
         uint256 gasLimit,
         uint64 minBlock,
-        bytes calldata callData
+        bytes calldata callData,
+        address requester
     )
         internal
         returns (bytes32 requestId)
     {
         requestId = keccak256(
             abi.encodePacked(
-                block.chainid, destinationDomain, targetContract, callData, block.timestamp, msg.sender, nonce
+                block.chainid, destinationDomain, targetContract, callData, block.timestamp, requester, nonce
             )
         );
 
         nonce++;
 
         bytes memory message = T1XChainMessage.encodeRead(
-            destinationDomain, TypeCasts.addressToBytes32(targetContract), requestId, callData
+            destinationDomain, TypeCasts.addressToBytes32(targetContract), requestId, callData, requester
         );
 
         // Using this selector to avoid hash collision
@@ -135,7 +136,7 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
 
         _sendMessage(destinationDomain, targetContract, gasLimit, requestReadSelector, message);
 
-        emit ReadRequested(requestId, destinationDomain, targetContract, tx.origin, gasLimit, minBlock, callData, nonce);
+        emit ReadRequested(requestId, destinationDomain, targetContract, requester, gasLimit, minBlock, callData, nonce);
     }
 
     function _sendMessage(
@@ -172,12 +173,16 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     }
 
     /**
-     * @notice Verifies a proof of read
-     * @param encodedProofOfRead The encoded proof of read which is formatted as following:
-     * abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
-     * @return requestId the request id of the proof of read
-     * @return result the result of the proof of read
-     */
+    * @notice Verifies a proof of read and returns the raw function result
+    * @dev The result is ABI-encoded as returned by the target function.
+    *      For functions returning dynamic types, you'll need to decode twice:
+    *      1. abi.decode(result, (bytes)) to get the inner bytes
+    *      2. abi.decode(innerBytes, (your expected type))
+    * @param encodedProofOfRead The encoded proof of read which is formatted as following:
+    * abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
+    * @return requestId The ID of the read request
+    * @return result The raw ABI-encoded return value from the target function
+    */
     function verifyProofOfRead(bytes calldata encodedProofOfRead) external view returns (bytes32, bytes memory) {
         (uint256 batchIndex, bytes32 requestId, uint256 position, bytes memory result, bytes memory proof) =
             abi.decode(encodedProofOfRead, (uint256, bytes32, uint256, bytes, bytes));

--- a/contracts/src/libraries/xChain/T1XChainReader.sol
+++ b/contracts/src/libraries/xChain/T1XChainReader.sol
@@ -63,6 +63,7 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
         uint256 gasLimit;
         uint64 minBlock;
         bytes callData;
+        address requester;
     }
 
     // ============ Errors ============

--- a/contracts/src/libraries/xChain/T1XChainReader.sol
+++ b/contracts/src/libraries/xChain/T1XChainReader.sol
@@ -104,7 +104,12 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
      */
     function requestRead(ReadRequest calldata request) external payable nonReentrant returns (bytes32 requestId) {
         return _processReadRequest(
-            request.destinationDomain, request.targetContract, request.gasLimit, request.minBlock, request.callData, request.requester
+            request.destinationDomain,
+            request.targetContract,
+            request.gasLimit,
+            request.minBlock,
+            request.callData,
+            request.requester
         );
     }
 
@@ -173,16 +178,16 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     }
 
     /**
-    * @notice Verifies a proof of read and returns the raw function result
-    * @dev The result is ABI-encoded as returned by the target function.
-    *      For functions returning dynamic types, you'll need to decode twice:
-    *      1. abi.decode(result, (bytes)) to get the inner bytes
-    *      2. abi.decode(innerBytes, (your expected type))
-    * @param encodedProofOfRead The encoded proof of read which is formatted as following:
-    * abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
-    * @return requestId The ID of the read request
-    * @return result The raw ABI-encoded return value from the target function
-    */
+     * @notice Verifies a proof of read and returns the raw function result
+     * @dev The result is ABI-encoded as returned by the target function.
+     *      For functions returning dynamic types, you'll need to decode twice:
+     *      1. abi.decode(result, (bytes)) to get the inner bytes
+     *      2. abi.decode(innerBytes, (your expected type))
+     * @param encodedProofOfRead The encoded proof of read which is formatted as following:
+     * abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
+     * @return requestId The ID of the read request
+     * @return result The raw ABI-encoded return value from the target function
+     */
     function verifyProofOfRead(bytes calldata encodedProofOfRead) external view returns (bytes32, bytes memory) {
         (uint256 batchIndex, bytes32 requestId, uint256 position, bytes memory result, bytes memory proof) =
             abi.decode(encodedProofOfRead, (uint256, bytes32, uint256, bytes, bytes));

--- a/contracts/src/test/7683/BaseTest.sol
+++ b/contracts/src/test/7683/BaseTest.sol
@@ -73,7 +73,7 @@ contract BaseTest is Test, DeployPermit2 {
 
     ProxyAdmin internal admin;
 
-    EmptyContract private placeholder;
+    EmptyContract internal placeholder;
 
     function __T1TestBase_setUp() internal {
         admin = new ProxyAdmin();

--- a/contracts/src/test/7683/BaseTest.sol
+++ b/contracts/src/test/7683/BaseTest.sol
@@ -18,9 +18,9 @@ import {
     GaslessCrossChainOrder,
     OnchainCrossChainOrder,
     ResolvedCrossChainOrder
-} from "intents-framework/ERC7683/IERC7683.sol";
+} from "../../../src/interfaces/IERC7683.sol";
 
-import { Base7683 } from "intents-framework/Base7683.sol";
+import { Base7683 } from "../../../src/7683/Base7683.sol";
 import { EmptyContract } from "../../misc/EmptyContract.sol";
 
 event Open(bytes32 indexed orderId, ResolvedCrossChainOrder resolvedOrder);

--- a/contracts/src/test/7683/T1BasicSwapE2E.t.sol
+++ b/contracts/src/test/7683/T1BasicSwapE2E.t.sol
@@ -8,9 +8,9 @@ import {
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
 import { BaseTest, TestInterchainGasPaymaster } from "./BaseTest.sol";
-import { Base7683 } from "intents-framework/Base7683.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { GaslessCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { Base7683 } from "../../../src/7683/Base7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { GaslessCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 
 import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
 import { L1MessageQueue } from "../../L1/rollup/L1MessageQueue.sol";

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -65,7 +65,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
         // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
         {
             // Construct the read request calldata
-            bytes memory result = l2T1ERC7683.getFilledOrderStatus(orderId);
+            bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
 
             // Generate merkle tree and proof for the result
             (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
@@ -93,7 +93,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
         // 4. Process the read request on L2 (destination chain) & Relay the result back to L1
         {
             // Construct the read request calldata
-            bytes memory result = l2T1ERC7683.getFilledOrderStatus(orderId);
+            bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
             // Generate merkle tree and proof for the result
             (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
 
@@ -139,7 +139,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
 
         (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-        bytes memory result = l2T1ERC7683.getFilledOrderStatus(orderId);
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
         (bytes32 root,) = _generateMerkleTree(requestId, result, position);
         originReader.commitProofOfReadRoot(batchIndex, root);
 
@@ -155,7 +155,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
 
         (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
-        bytes memory result = l2T1ERC7683.getFilledOrderStatus(orderId);
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
         (bytes32 root,) = _generateMerkleTree(requestId, result, position);
         originReader.commitProofOfReadRoot(batchIndex, root);
 
@@ -197,7 +197,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
         (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
 
         {
-            bytes memory result = l2T1ERC7683.getFilledOrderStatus(orderId);
+            bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
             (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
 
             originReader.commitProofOfReadRoot(batchIndex, root);

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -3,8 +3,8 @@ pragma solidity ^0.8.25;
 
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
-import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
-import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
 
 import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
 import { T1BasicSwapE2E } from "./T1BasicSwapE2E.t.sol";

--- a/contracts/src/test/7683/TvlThresholdTest.t.sol
+++ b/contracts/src/test/7683/TvlThresholdTest.t.sol
@@ -8,12 +8,16 @@ import { ISignatureTransfer } from "@uniswap/permit2/src/interfaces/IPermit2.sol
 import { BaseTest } from "./BaseTest.sol";
 import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
 import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
 import {
     OnchainCrossChainOrder,
     GaslessCrossChainOrder,
     ResolvedCrossChainOrder
 } from "../../../src/interfaces/IERC7683.sol";
+import { ISignatureTransfer } from "@uniswap/permit2/src/interfaces/IPermit2.sol";
 
 contract TvlThresholdTest is BaseTest {
     using TypeCasts for address;

--- a/contracts/src/test/7683/TvlThresholdTest.t.sol
+++ b/contracts/src/test/7683/TvlThresholdTest.t.sol
@@ -1,17 +1,23 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { ISignatureTransfer } from "@uniswap/permit2/src/interfaces/IPermit2.sol";
+
 import { BaseTest } from "./BaseTest.sol";
 import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
 import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
-
-import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
-import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
 import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
-import { OnchainCrossChainOrder, GaslessCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
+import {
+    OnchainCrossChainOrder,
+    GaslessCrossChainOrder,
+    ResolvedCrossChainOrder
+} from "../../../src/interfaces/IERC7683.sol";
 
 contract TvlThresholdTest is BaseTest {
     using TypeCasts for address;
+    using TypeCasts for bytes32;
 
     event Paused(address account);
     event Unpaused(address account);
@@ -32,7 +38,7 @@ contract TvlThresholdTest is BaseTest {
         t1ERC7683 = T1ERC7683(payable(_deployProxy(address(0))));
         admin.upgrade(
             ITransparentUpgradeableProxy(address(t1ERC7683)),
-            address(new T1ERC7683(address(0), address(reader), uint32(origin)))
+            address(new T1ERC7683(permit2, address(reader), uint32(origin)))
         );
         t1ERC7683.initialize(address(t1ERC7683));
     }
@@ -73,19 +79,53 @@ contract TvlThresholdTest is BaseTest {
         OrderData memory orderData = _prepareOrderData();
         OnchainCrossChainOrder memory order =
             _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
-        bytes32 orderId = OrderEncoder.id(orderData);
 
         vm.startPrank(kakaroto);
         inputToken.approve(address(t1ERC7683), type(uint256).max);
         t1ERC7683.open(order);
         vm.stopPrank();
 
+        bytes32 orderId = OrderEncoder.id(orderData);
         bytes32 status = t1ERC7683.orderStatus(orderId);
-
         assertEq(status, t1ERC7683.OPENED());
     }
 
-    // function test_canOpenForWhenNotPaused() public { }
+    function test_canOpenForWhenNotPaused() public {
+        vm.prank(kakaroto);
+        inputToken.approve(permit2, type(uint256).max);
+
+        uint32 openDeadline = uint32(block.timestamp + 100);
+        OrderData memory orderData = _prepareOrderData();
+        GaslessCrossChainOrder memory order = _prepareGaslessOrder(
+            address(t1ERC7683),
+            kakaroto,
+            orderData.originDomain,
+            OrderEncoder.encode(orderData),
+            orderData.senderNonce,
+            openDeadline,
+            orderData.fillDeadline,
+            OrderEncoder.orderDataType()
+        );
+        bytes memory originFillerData = new bytes(0);
+
+        ResolvedCrossChainOrder memory resolvedOrder = t1ERC7683.resolveFor(order, originFillerData);
+        bytes memory sig = _getSignature(
+            address(t1ERC7683),
+            t1ERC7683.witnessHash(resolvedOrder),
+            orderData.inputToken.bytes32ToAddress(),
+            order.nonce,
+            orderData.amountIn,
+            openDeadline,
+            kakarotoPK
+        );
+
+        vm.prank(vegeta);
+        t1ERC7683.openFor(order, sig, new bytes(0));
+
+        bytes32 orderId = OrderEncoder.id(orderData);
+        bytes32 status = t1ERC7683.orderStatus(orderId);
+        assertEq(status, t1ERC7683.OPENED());
+    }
 
     function test_cannotOpenWhenPaused() public {
         t1ERC7683.pause();

--- a/contracts/src/test/7683/TvlThresholdTest.t.sol
+++ b/contracts/src/test/7683/TvlThresholdTest.t.sol
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { BaseTest } from "./BaseTest.sol";
+import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
+import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder, GaslessCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
+
+contract TvlThresholdTest is BaseTest {
+    using TypeCasts for address;
+
+    event Paused(address account);
+    event Unpaused(address account);
+
+    T1XChainReader internal reader;
+    T1ERC7683 internal t1ERC7683;
+
+    function setUp() public virtual override {
+        super.setUp();
+        __T1TestBase_setUp();
+
+        reader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(reader)),
+            address(new T1XChainReader(address(placeholder), address(this)))
+        );
+
+        t1ERC7683 = T1ERC7683(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(t1ERC7683)),
+            address(new T1ERC7683(address(0), address(reader), uint32(origin)))
+        );
+        t1ERC7683.initialize(address(t1ERC7683));
+    }
+
+    function test_pauseAndUnpause() public {
+        // Test that only owner can pause
+        vm.prank(address(0xbeef));
+        vm.expectRevert("Ownable: caller is not the owner");
+        t1ERC7683.pause();
+
+        // Test pause by owner
+        t1ERC7683.pause();
+        assertTrue(t1ERC7683.paused(), "Contract should be paused");
+
+        // Test that only owner can unpause
+        vm.prank(address(0xbeef));
+        vm.expectRevert("Ownable: caller is not the owner");
+        t1ERC7683.unpause();
+
+        // Test unpause by owner
+        t1ERC7683.unpause();
+        assertFalse(t1ERC7683.paused(), "Contract should be unpaused");
+    }
+
+    function test_pauseAndUnpauseEvents() public {
+        // Test pause event
+        vm.expectEmit(true, true, true, true);
+        emit Paused(address(this));
+        t1ERC7683.pause();
+
+        // Test unpause event
+        vm.expectEmit(true, true, true, true);
+        emit Unpaused(address(this));
+        t1ERC7683.unpause();
+    }
+
+    function test_canOpenWhenNotPaused() public {
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+        bytes32 orderId = OrderEncoder.id(orderData);
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        t1ERC7683.open(order);
+        vm.stopPrank();
+
+        bytes32 status = t1ERC7683.orderStatus(orderId);
+
+        assertEq(status, t1ERC7683.OPENED());
+    }
+
+    // function test_canOpenForWhenNotPaused() public { }
+
+    function test_cannotOpenWhenPaused() public {
+        t1ERC7683.pause();
+
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        vm.expectRevert("Pausable: paused");
+        t1ERC7683.open(order);
+        vm.stopPrank();
+    }
+
+    function test_cannotOpenForWhenPaused() public {
+        t1ERC7683.pause();
+
+        OrderData memory orderData = _prepareOrderData();
+        GaslessCrossChainOrder memory order = _prepareGaslessOrder(
+            address(t1ERC7683),
+            kakaroto,
+            uint64(origin),
+            OrderEncoder.encode(orderData),
+            1, // permitNonce
+            uint32(block.timestamp + 100), // openDeadline
+            orderData.fillDeadline,
+            OrderEncoder.orderDataType()
+        );
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        vm.expectRevert("Pausable: paused");
+        t1ERC7683.openFor(order, "", "");
+        vm.stopPrank();
+    }
+
+    function _prepareOrderData() internal view returns (OrderData memory) {
+        return OrderData({
+            sender: TypeCasts.addressToBytes32(kakaroto),
+            recipient: TypeCasts.addressToBytes32(karpincho),
+            inputToken: TypeCasts.addressToBytes32(address(inputToken)),
+            outputToken: TypeCasts.addressToBytes32(address(outputToken)),
+            amountIn: amount,
+            amountOut: amount,
+            senderNonce: 1,
+            originDomain: origin,
+            destinationDomain: destination,
+            destinationSettler: address(t1ERC7683).addressToBytes32(),
+            fillDeadline: uint32(block.timestamp + 1 hours),
+            data: new bytes(0)
+        });
+    }
+}

--- a/reth/README.md
+++ b/reth/README.md
@@ -7,4 +7,4 @@
 [rust]: https://www.rust-lang.org/
 [rust-badge]: https://img.shields.io/badge/Rust-stable-orange?logo=rust
 
-t1 extenstion of reth
+t1 extension of reth


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- `T1ERC7683`: add tuple decoding to handle offset and length prefix added by off-chain relayer when executing xChainRead
- add `requester` field to `ReadRequest` struct this allows the off chain relayer to index proofs based on the sender of the request. otherwise there is no way to easily attribute the xCR requests
- add better natspec about ABI decoding on `verifyProofOfRead`
- Adds the metadata from my v0.5 contract (re)deployment
- Miscellaneous cleanup changes
<!--- Describe your changes in detail -->

## How Has This Been Tested?
tested against a new Postman instance on v0.5, with a [successful tx](https://sepolia.basescan.org/tx/0x082897c1ca0a98eacc9845dbcdc00003eb7a202d392a026282ad79d3d53d466e).

You can test it yourself:

1. Run one of the following:
```
// open USDT intent from Base to Arbitrum
forge script ./script/test/7683/T1ERC7683BaseToArb.s.sol:AliceSetupScript --broadcast
// open USDT intent from Arbitrum to Base
forge script ./script/test/7683/T1ERC7683ArbToBase.s.sol:AliceSetupScript --broadcast
```

2. go to `https://api.v05.t1protocol.com/api/read-proofs?address=<your address>&page=1&page_size=100`

3. copy the value in `handle_read_result_with_proof_calldata`

4. go to the block explorer (or use cast) and execute the [handleReadResultWithProof](https://sepolia.basescan.org/address/0xfc39ed3734f8660c96ea0523353a1cfd242e6c7d#writeContract#F2), passing in the value from step 3
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
-   [x] Release
-   [x] Fix

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.