### PR TITLE
feat: implement pausable pattern for 7683

### DIFF
--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -2,9 +2,18 @@
 pragma solidity ^0.8.25;
 
 import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { PausableUpgradeable } from "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {
+    GaslessCrossChainOrder,
+    ResolvedCrossChainOrder,
+    OnchainCrossChainOrder
+} from "intents-framework/ERC7683/IERC7683.sol";
 import { Hyperlane7683Message } from "intents-framework/libs/Hyperlane7683Message.sol";
 import { BasicSwap7683 } from "intents-framework/BasicSwap7683.sol";
 import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
 import { T1XChainReader } from "../libraries/xChain/T1XChainReader.sol";
 /**
@@ -14,7 +23,9 @@ import { T1XChainReader } from "../libraries/xChain/T1XChainReader.sol";
  * @dev Implements both push-based messaging and pull-based verification for orders
  */
 
-contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
+contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
+    using SafeERC20 for IERC20;
+
     // ============ Constants ============
     uint32 public immutable localDomain;
     T1XChainReader public immutable xChainRead;
@@ -47,7 +58,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
 
     // ============ Errors ============
     error FunctionNotImplemented(string functionName);
-    error EthNotAllowed();
     error SettlementFailed();
     error RefundFailed();
 
@@ -67,6 +77,54 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable {
     function initialize(address _counterpart) external initializer {
         counterpart = _counterpart;
         __Ownable_init();
+        __Pausable_init();
+    }
+
+    function openFor(
+        GaslessCrossChainOrder calldata _order,
+        bytes calldata _signature,
+        bytes calldata _originFillerData
+    )
+        external
+        override
+        whenNotPaused
+    {
+        if (block.timestamp > _order.openDeadline) revert OrderOpenExpired();
+        if (_order.originSettler != address(this)) revert InvalidGaslessOrderSettler();
+        if (_order.originChainId != _localDomain()) revert InvalidGaslessOrderOrigin();
+
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) =
+            _resolveOrder(_order, _originFillerData);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(_order.user, nonce);
+
+        _permitTransferFrom(resolvedOrder, _signature, _order.nonce, address(this));
+
+        emit Open(orderId, resolvedOrder);
+    }
+
+    function open(OnchainCrossChainOrder calldata _order) external payable override whenNotPaused {
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) = _resolveOrder(_order);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(msg.sender, nonce);
+
+        uint256 totalValue;
+        for (uint256 i = 0; i < resolvedOrder.minReceived.length; i++) {
+            address token = TypeCasts.bytes32ToAddress(resolvedOrder.minReceived[i].token);
+            if (token == address(0)) {
+                totalValue += resolvedOrder.minReceived[i].amount;
+            } else {
+                IERC20(token).safeTransferFrom(msg.sender, address(this), resolvedOrder.minReceived[i].amount);
+            }
+        }
+
+        if (msg.value != totalValue) revert InvalidNativeAmount();
+
+        emit Open(orderId, resolvedOrder);
     }
 
     /// @notice Initiates a pull-based settlement verification for an order

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -80,6 +80,28 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
         __Pausable_init();
     }
 
+    function open(OnchainCrossChainOrder calldata _order) external payable override whenNotPaused {
+        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) = _resolveOrder(_order);
+
+        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
+        orderStatus[orderId] = OPENED;
+        _useNonce(msg.sender, nonce);
+
+        uint256 totalValue;
+        for (uint256 i = 0; i < resolvedOrder.minReceived.length; i++) {
+            address token = TypeCasts.bytes32ToAddress(resolvedOrder.minReceived[i].token);
+            if (token == address(0)) {
+                totalValue += resolvedOrder.minReceived[i].amount;
+            } else {
+                IERC20(token).safeTransferFrom(msg.sender, address(this), resolvedOrder.minReceived[i].amount);
+            }
+        }
+
+        if (msg.value != totalValue) revert InvalidNativeAmount();
+
+        emit Open(orderId, resolvedOrder);
+    }
+
     function openFor(
         GaslessCrossChainOrder calldata _order,
         bytes calldata _signature,
@@ -101,28 +123,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
         _useNonce(_order.user, nonce);
 
         _permitTransferFrom(resolvedOrder, _signature, _order.nonce, address(this));
-
-        emit Open(orderId, resolvedOrder);
-    }
-
-    function open(OnchainCrossChainOrder calldata _order) external payable override whenNotPaused {
-        (ResolvedCrossChainOrder memory resolvedOrder, bytes32 orderId, uint256 nonce) = _resolveOrder(_order);
-
-        openOrders[orderId] = abi.encode(_order.orderDataType, _order.orderData);
-        orderStatus[orderId] = OPENED;
-        _useNonce(msg.sender, nonce);
-
-        uint256 totalValue;
-        for (uint256 i = 0; i < resolvedOrder.minReceived.length; i++) {
-            address token = TypeCasts.bytes32ToAddress(resolvedOrder.minReceived[i].token);
-            if (token == address(0)) {
-                totalValue += resolvedOrder.minReceived[i].amount;
-            } else {
-                IERC20(token).safeTransferFrom(msg.sender, address(this), resolvedOrder.minReceived[i].amount);
-            }
-        }
-
-        if (msg.value != totalValue) revert InvalidNativeAmount();
 
         emit Open(orderId, resolvedOrder);
     }
@@ -191,6 +191,14 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
         }
 
         emit SettlementVerified(orderId, isSettled);
+    }
+
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     function getFilledOrderStatus(bytes32 orderId) external view returns (bytes memory) {

--- a/contracts/src/test/7683/BaseTest.sol
+++ b/contracts/src/test/7683/BaseTest.sol
@@ -73,7 +73,7 @@ contract BaseTest is Test, DeployPermit2 {
 
     ProxyAdmin internal admin;
 
-    EmptyContract private placeholder;
+    EmptyContract internal placeholder;
 
     function __T1TestBase_setUp() internal {
         admin = new ProxyAdmin();

--- a/contracts/src/test/7683/TvlThresholdTest.t.sol
+++ b/contracts/src/test/7683/TvlThresholdTest.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { BaseTest } from "./BaseTest.sol";
+import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
+import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { OrderData, OrderEncoder } from "intents-framework/libs/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+import { GaslessCrossChainOrder } from "intents-framework/ERC7683/IERC7683.sol";
+
+contract TvlThresholdTest is BaseTest {
+    using TypeCasts for address;
+
+    event Paused(address account);
+    event Unpaused(address account);
+
+    T1XChainReader internal reader;
+    T1ERC7683 internal t1ERC7683;
+
+    function setUp() public virtual override {
+        super.setUp();
+        __T1TestBase_setUp();
+
+        reader = T1XChainReader(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(reader)),
+            address(new T1XChainReader(address(placeholder), address(this)))
+        );
+
+        t1ERC7683 = T1ERC7683(payable(_deployProxy(address(0))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(t1ERC7683)),
+            address(new T1ERC7683(address(0), address(reader), uint32(origin)))
+        );
+        t1ERC7683.initialize(address(t1ERC7683));
+    }
+
+    function test_pauseAndUnpause() public {
+        // Test that only owner can pause
+        vm.prank(address(0xbeef));
+        vm.expectRevert("Ownable: caller is not the owner");
+        t1ERC7683.pause();
+
+        // Test pause by owner
+        t1ERC7683.pause();
+        assertTrue(t1ERC7683.paused(), "Contract should be paused");
+
+        // Test that only owner can unpause
+        vm.prank(address(0xbeef));
+        vm.expectRevert("Ownable: caller is not the owner");
+        t1ERC7683.unpause();
+
+        // Test unpause by owner
+        t1ERC7683.unpause();
+        assertFalse(t1ERC7683.paused(), "Contract should be unpaused");
+    }
+
+    function test_pauseAndUnpauseEvents() public {
+        // Test pause event
+        vm.expectEmit(true, true, true, true);
+        emit Paused(address(this));
+        t1ERC7683.pause();
+
+        // Test unpause event
+        vm.expectEmit(true, true, true, true);
+        emit Unpaused(address(this));
+        t1ERC7683.unpause();
+    }
+
+    function test_canOpenWhenNotPaused() public {
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+        bytes32 orderId = OrderEncoder.id(orderData);
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        t1ERC7683.open(order);
+        vm.stopPrank();
+
+        bytes32 status = t1ERC7683.orderStatus(orderId);
+
+        assertEq(status, t1ERC7683.OPENED());
+    }
+
+    // function test_canOpenForWhenNotPaused() public { }
+
+    function test_cannotOpenWhenPaused() public {
+        t1ERC7683.pause();
+
+        OrderData memory orderData = _prepareOrderData();
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        vm.expectRevert("Pausable: paused");
+        t1ERC7683.open(order);
+        vm.stopPrank();
+    }
+
+    function test_cannotOpenForWhenPaused() public {
+        t1ERC7683.pause();
+
+        OrderData memory orderData = _prepareOrderData();
+        GaslessCrossChainOrder memory order = _prepareGaslessOrder(
+            address(t1ERC7683),
+            kakaroto,
+            uint64(origin),
+            OrderEncoder.encode(orderData),
+            1, // permitNonce
+            uint32(block.timestamp + 100), // openDeadline
+            orderData.fillDeadline,
+            OrderEncoder.orderDataType()
+        );
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(t1ERC7683), type(uint256).max);
+        vm.expectRevert("Pausable: paused");
+        t1ERC7683.openFor(order, "", "");
+        vm.stopPrank();
+    }
+
+    function _prepareOrderData() internal view returns (OrderData memory) {
+        return OrderData({
+            sender: TypeCasts.addressToBytes32(kakaroto),
+            recipient: TypeCasts.addressToBytes32(karpincho),
+            inputToken: TypeCasts.addressToBytes32(address(inputToken)),
+            outputToken: TypeCasts.addressToBytes32(address(outputToken)),
+            amountIn: amount,
+            amountOut: amount,
+            senderNonce: 1,
+            originDomain: origin,
+            destinationDomain: destination,
+            destinationSettler: address(t1ERC7683).addressToBytes32(),
+            fillDeadline: uint32(block.timestamp + 1 hours),
+            data: new bytes(0)
+        });
+    }
+}


### PR DESCRIPTION
## Description

Implemented a pausable pattern on `open` and `openFor` function to allow for blocking any new intent open.

## Motivation and Context

We want to assume that our Intent Bridges could be exploited and the funds locked in 7683 Escrows could be drained. If that happens, we will repay the users that lost their funds. We are however only willing to do that up to a threshold.

## How Has This Been Tested?

Introduced a `TvlThresholdTest.sol` test contract to specifically test the behavior of those functions depending on the pause state.


## Types of changes (remove all unchecked types)

-   [ x ] New feature (non-breaking change which adds functionality)

## Checklist:

-   [ ] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.