### PR TITLE
feat: implement upgrade script for chain reader

### DIFF
--- a/contracts/script/README.md
+++ b/contracts/script/README.md
@@ -110,8 +110,20 @@ Miscellaneous Scripts:
 Scripts to upgrade contract implementations:
 
 - [T1Chain implementation](./upgrade/UpgradeT1Chain.s.sol)
+
   ```bash
   forge script ./script/upgrade/UpgradeT1Chain.s.sol:UpgradeT1Chain --rpc-url $T1_L1_RPC --broadcast
+  ```
+
+- [T1XChainReader implementation](./upgrade/UpgradeT1XChainReader.s.sol) - Upgrade on Sepolia (production)
+
+  ```bash
+  forge script ./script/upgrade/UpgradeT1XChainReader.s.sol:UpgradeT1XChainReader --rpc-url $T1_L1_RPC --broadcast
+  ```
+
+- [T1XChainReader implementation (Local)](./upgrade/UpgradeT1XChainReaderLocal.s.sol) - Upgrade on local network
+  ```bash
+  forge script ./script/upgrade/UpgradeT1XChainReaderLocal.s.sol:UpgradeT1XChainReaderLocal --rpc-url localhost --broadcast
   ```
 
 ## Deploying 7683 to Arbitrum Sepolia and Base Sepolia

--- a/contracts/script/deploy/DeployLocalT1XChainReader.s.sol
+++ b/contracts/script/deploy/DeployLocalT1XChainReader.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+
+import { T1XChainReader } from "../../src/libraries/xChain/T1XChainReader.sol";
+
+contract DeployLocalT1XChainReader is DeploymentUtils {
+    function run() external {
+        logStart("DeployXChainRead to Local");
+
+        uint256 L1_DEPLOYER_PRIVATE_KEY = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
+        address L1_T1_MESSENGER = vm.envAddress("L1_T1_MESSENGER_PROXY_ADDR");
+        address L1_PROXY_ADMIN_ADDR = vm.envAddress("L1_PROXY_ADMIN_ADDR");
+        address L1_SIGNER = vm.envAddress("L1_SIGNER");
+        ProxyAdmin proxyAdmin = ProxyAdmin(L1_PROXY_ADMIN_ADDR);
+
+        vm.startBroadcast(L1_DEPLOYER_PRIVATE_KEY);
+
+        T1XChainReader impl = new T1XChainReader(address(L1_T1_MESSENGER), L1_SIGNER);
+        logAddress("L1_T1_X_CHAIN_READ_IMPLEMENTATION_ADDR", address(impl));
+
+        TransparentUpgradeableProxy proxy =
+            new TransparentUpgradeableProxy(address(impl), address(proxyAdmin), new bytes(0));
+        logAddress("L1_T1_X_CHAIN_READ_PROXY_ADDR", address(proxy));
+
+        vm.stopBroadcast();
+
+        logEnd("DeployXChainRead to L1");
+    }
+}

--- a/contracts/script/upgrade/UpgradeT1XChainReader.s.sol
+++ b/contracts/script/upgrade/UpgradeT1XChainReader.s.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { UpgradeT1XChainReaderLogic } from "./UpgradeT1XChainReaderLogic.sol";
+
+/**
+ * @title UpgradeT1XChainReader
+ * @dev Script to upgrade the T1XChainReader implementation on Sepolia
+ *
+ * Usage:
+ * forge script ./script/upgrade/UpgradeT1XChainReader.s.sol:UpgradeT1XChainReader --rpc-url $T1_L1_RPC --broadcast
+ */
+
+// solhint-disable max-states-count
+// solhint-disable var-name-mixedcase
+
+contract UpgradeT1XChainReader is UpgradeT1XChainReaderLogic {
+    function run() external {
+        logStart("UpgradeT1XChainReader.s.sol");
+        vm.createSelectFork(vm.rpcUrl("sepolia"));
+        _performUpgrade(false);
+        logEnd("UpgradeT1XChainReader.s.sol");
+    }
+}

--- a/contracts/script/upgrade/UpgradeT1XChainReaderLocal.s.sol
+++ b/contracts/script/upgrade/UpgradeT1XChainReaderLocal.s.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { UpgradeT1XChainReaderLogic } from "./UpgradeT1XChainReaderLogic.sol";
+
+/**
+ * @title UpgradeT1XChainReaderLocal
+ * @dev Script to upgrade the T1XChainReader implementation on local network
+ *
+ * Usage:
+ * forge script ./script/upgrade/UpgradeT1XChainReaderLocal.s.sol:UpgradeT1XChainReaderLocal --rpc-url localhost
+ * --broadcast
+ */
+contract UpgradeT1XChainReaderLocal is UpgradeT1XChainReaderLogic {
+    function run() external {
+        logStart("UpgradeT1XChainReaderLocal.s.sol");
+        _performUpgrade(true);
+        logEnd("UpgradeT1XChainReaderLocal.s.sol");
+    }
+}

--- a/contracts/script/upgrade/UpgradeT1XChainReaderLogic.sol
+++ b/contracts/script/upgrade/UpgradeT1XChainReaderLogic.sol
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+
+import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
+
+import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+
+import { T1XChainReader } from "../../src/libraries/xChain/T1XChainReader.sol";
+import { T1Owner } from "../../src/misc/T1Owner.sol";
+
+/**
+ * @title UpgradeT1XChainReaderLogic
+ * @dev Contains the core business logic for upgrading T1XChainReader implementation
+ */
+abstract contract UpgradeT1XChainReaderLogic is Script, DeploymentUtils {
+    // Security council role
+    bytes32 internal constant SECURITY_COUNCIL_NO_DELAY_ROLE = keccak256("SECURITY_COUNCIL_NO_DELAY_ROLE");
+
+    /**
+     * @dev Deploys a new T1XChainReader implementation
+     * @return implementation The address of the new implementation
+     */
+    function _deployNewImplementation() internal returns (T1XChainReader implementation) {
+        uint256 deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
+        address messengerProxyAddr = vm.envAddress("L1_T1_MESSENGER_PROXY_ADDR");
+        address signerAddr = vm.envAddress("L1_SIGNER");
+
+        vm.startBroadcast(deployerPrivateKey);
+        implementation = new T1XChainReader(messengerProxyAddr, signerAddr);
+        vm.stopBroadcast();
+
+        logAddress("L1_T1_X_CHAIN_READ_IMPLEMENTATION_ADDR_NEW", address(implementation));
+
+        console.log("New T1XChainReader implementation deployed at:", vm.toString(address(implementation)));
+    }
+
+    /**
+     * @dev Performs the upgrade using T1Owner (for production networks)
+     * @param newImplementation The new implementation address
+     */
+    function _upgradeViaT1Owner(address newImplementation) internal {
+        uint256 securityCouncilPrivateKey = vm.envUint("L1_SECURITY_COUNCIL_PRIVATE_KEY");
+        address proxyAdminAddr = vm.envAddress("L1_PROXY_ADMIN_ADDR");
+        address t1OwnerAddr = vm.envAddress("L1_T1_OWNER_ADDR");
+        address xChainReaderProxyAddr = vm.envAddress("L1_T1_X_CHAIN_READ_PROXY_ADDR");
+
+        vm.startBroadcast(securityCouncilPrivateKey);
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(proxyAdminAddr);
+
+        address currentImplementation =
+            proxyAdmin.getProxyImplementation(ITransparentUpgradeableProxy(xChainReaderProxyAddr));
+
+        console.log(
+            "Upgrading T1XChainReader implementation from",
+            vm.toString(currentImplementation),
+            "to new implementation",
+            vm.toString(newImplementation)
+        );
+
+        try T1Owner(payable(t1OwnerAddr)).execute(
+            proxyAdminAddr,
+            0,
+            abi.encodeWithSelector(
+                proxyAdmin.upgrade.selector, ITransparentUpgradeableProxy(xChainReaderProxyAddr), newImplementation
+            ),
+            SECURITY_COUNCIL_NO_DELAY_ROLE
+        ) {
+            console.log("T1XChainReader upgrade successful");
+            _verifyUpgrade(proxyAdminAddr, xChainReaderProxyAddr, newImplementation);
+        } catch Error(string memory reason) {
+            console.log("T1XChainReader upgrade failed:", reason);
+            revert(string(abi.encodePacked("T1XChainReader upgrade failed: ", reason)));
+        } catch (bytes memory) {
+            console.log("T1XChainReader upgrade failed with unknown error");
+            revert("T1XChainReader upgrade failed with unknown error");
+        }
+
+        vm.stopBroadcast();
+    }
+
+    /**
+     * @dev Performs the upgrade directly via ProxyAdmin (for local testing)
+     * @param newImplementation The new implementation address
+     */
+    function _upgradeDirectly(address newImplementation) internal {
+        uint256 deployerPrivateKey = vm.envUint("L1_DEPLOYER_PRIVATE_KEY");
+        address proxyAdminAddr = vm.envAddress("L1_PROXY_ADMIN_ADDR");
+        address xChainReaderProxyAddr = vm.envAddress("L1_T1_X_CHAIN_READ_PROXY_ADDR");
+
+        vm.startBroadcast(deployerPrivateKey);
+
+        ProxyAdmin proxyAdmin = ProxyAdmin(proxyAdminAddr);
+
+        address currentImplementation =
+            proxyAdmin.getProxyImplementation(ITransparentUpgradeableProxy(xChainReaderProxyAddr));
+
+        console.log(
+            "Upgrading T1XChainReader implementation from",
+            vm.toString(currentImplementation),
+            "to new implementation",
+            vm.toString(newImplementation)
+        );
+
+        proxyAdmin.upgrade(ITransparentUpgradeableProxy(xChainReaderProxyAddr), newImplementation);
+
+        console.log("T1XChainReader upgrade successful");
+        _verifyUpgrade(proxyAdminAddr, xChainReaderProxyAddr, newImplementation);
+
+        vm.stopBroadcast();
+    }
+
+    /**
+     * @dev Verifies that the upgrade was successful
+     * @param proxyAdminAddr The ProxyAdmin address
+     * @param xChainReaderProxyAddr The proxy address
+     * @param expectedImplementation The expected implementation address
+     */
+    function _verifyUpgrade(
+        address proxyAdminAddr,
+        address xChainReaderProxyAddr,
+        address expectedImplementation
+    )
+        internal
+        view
+    {
+        ProxyAdmin proxyAdmin = ProxyAdmin(proxyAdminAddr);
+        address actualImplementation =
+            proxyAdmin.getProxyImplementation(ITransparentUpgradeableProxy(xChainReaderProxyAddr));
+
+        if (actualImplementation == expectedImplementation) {
+            console.log("Verification successful: Implementation is now", vm.toString(actualImplementation));
+        } else {
+            console.log(
+                "Verification failed: Expected",
+                vm.toString(expectedImplementation),
+                "but got",
+                vm.toString(actualImplementation)
+            );
+            revert("Upgrade verification failed");
+        }
+    }
+
+    /**
+     * @dev Main upgrade function that handles the complete upgrade process
+     * @param local If the deployment is on a local network
+     */
+    function _performUpgrade(bool local) internal {
+        // Deploy new implementation
+        T1XChainReader newImplementation = _deployNewImplementation();
+
+        // Perform upgrade based on configuration
+        if (local) {
+            _upgradeDirectly(address(newImplementation));
+        } else {
+            _upgradeViaT1Owner(address(newImplementation));
+        }
+    }
+}


### PR DESCRIPTION
## Description

Add scripts to run an upgrade of the chain reader contract on sepolia.

Also adds scripts for local tests.

## Motivation and Context

The xChainReader contract is upgradeable but we don’t currently have a script to upgrade it. In fact we needed this recently in order to update the prover on the contract to avoid a signer clash on Postman, but were unable to quickly do so. Having a ready upgrade script would have helped us there.

## How Has This Been Tested?

Ran a deployment and then upgrade on a local network.

## Types of changes (remove all unchecked types)

-   [x] New feature (non-breaking change which adds functionality)
-   [x] Docs

## Checklist:

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.