### PR TITLE
feat: remove gasLimit and payable requirement from T1XChainReader

### DIFF
--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -125,7 +125,7 @@ contract SettlementScript is Script {
         // NOTE - orderId logged from the first step goes here (remove 0x first)
         bytes32 orderId = hex"";
 
-        l1_7683.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
+        l1_7683.verifySettlement(DESTINATION_CHAIN, orderId);
 
         vm.stopBroadcast();
     }

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -125,7 +125,7 @@ contract SettlementScript is Script {
         // NOTE - orderId logged from the first step goes here (remove 0x first)
         bytes32 orderId = hex"";
 
-        l1_7683.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
+        l1_7683.verifySettlement(DESTINATION_CHAIN, orderId);
 
         vm.stopBroadcast();
     }

--- a/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
@@ -123,7 +123,7 @@ contract SettlementScript is Script {
         // NOTE - orderId logged from the first step goes here (remove 0x first)
         bytes32 orderId = hex"";
 
-        l1_7683.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
+        l1_7683.verifySettlement(DESTINATION_CHAIN, orderId);
 
         vm.stopBroadcast();
     }

--- a/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
@@ -122,7 +122,7 @@ contract SettlementScript is Script {
         // NOTE - orderId logged from the first step goes here (remove 0x first)
         bytes32 orderId = hex"";
 
-        l2_7683.verifySettlement(DESTINATION_CHAIN, 1_000_000, orderId);
+        l2_7683.verifySettlement(DESTINATION_CHAIN, orderId);
 
         vm.stopBroadcast();
     }

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -125,18 +125,9 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
 
     /// @notice Initiates a pull-based settlement verification for an order
     /// @param destinationDomain The domain of the destination chain
-    /// @param gasLimit The gas limit for the read operation
     /// @param orderId The ID of the order to verify
     /// @return requestId The ID of the read request
-    function verifySettlement(
-        uint32 destinationDomain,
-        uint256 gasLimit,
-        bytes32 orderId
-    )
-        external
-        payable
-        returns (bytes32 requestId)
-    {
+    function verifySettlement(uint32 destinationDomain, bytes32 orderId) external returns (bytes32 requestId) {
         // Check if the order exists and is in a valid state
         if (orderStatus[orderId] != OPENED) revert InvalidOrderStatus();
 
@@ -146,14 +137,13 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
         T1XChainReader.ReadRequest memory readRequest = T1XChainReader.ReadRequest({
             destinationDomain: destinationDomain,
             targetContract: counterpart,
-            gasLimit: gasLimit,
             minBlock: 0,
             callData: callData,
             requester: msg.sender
         });
 
         // Request the cross-chain read
-        requestId = xChainRead.requestRead{ value: msg.value }(readRequest);
+        requestId = xChainRead.requestRead(readRequest);
 
         readRequestToOrderId[requestId] = orderId;
 

--- a/contracts/src/libraries/xChain/T1XChainReader.sol
+++ b/contracts/src/libraries/xChain/T1XChainReader.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import { WithdrawTrieVerifier } from "../verifier/WithdrawTrieVerifier.sol";
 
@@ -8,7 +9,7 @@ import { WithdrawTrieVerifier } from "../verifier/WithdrawTrieVerifier.sol";
  * @title T1XChainReader
  * @notice Facilitates reading data from contracts on other chains through t1
  */
-contract T1XChainReader is ReentrancyGuardUpgradeable {
+contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
     // ============ Events ============
 
     /**
@@ -17,7 +18,6 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
      * @param destinationDomain Domain ID of the target chain
      * @param targetContract Address of the contract to read from
      * @param requester Address who initiated the read request
-     * @param gasLimit The gas limit for the read operation
      * @param minBlock the minimum block on the target chain that you will accept the read to be executed
      * @param callData The encoded function call
      * @param nonce The nonce of the read request
@@ -27,7 +27,6 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
         uint32 indexed destinationDomain,
         address indexed targetContract,
         address requester,
-        uint256 gasLimit,
         uint64 minBlock,
         bytes callData,
         uint256 nonce
@@ -52,9 +51,6 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
     struct ReadRequest {
         uint32 destinationDomain;
         address targetContract;
-        /// @dev Off-chain relayer uses gasLimit when executing the call on destination chain.
-        ///      Value is unused on-chain but retained for the relayer.
-        uint256 gasLimit;
         uint64 minBlock;
         bytes callData;
         address requester;
@@ -66,7 +62,6 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
     error ZeroAddress();
     error InvalidBatchIndex();
     error InvalidProof();
-    error EtherNotAccepted();
 
     // ============ Variables ============
     uint256 public nonce;
@@ -92,26 +87,18 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
 
     /**
      * @notice Initiates a cross-chain read request
-     * @dev `gasLimit` is emitted for the off-chain relayer and unused on-chain
      * @param request ReadRequest
      * @return requestId Unique identifier for tracking this request
      */
-    function requestRead(ReadRequest calldata request) external payable nonReentrant returns (bytes32 requestId) {
-        if (msg.value != 0) revert EtherNotAccepted();
+    function requestRead(ReadRequest calldata request) external nonReentrant returns (bytes32 requestId) {
         return _processReadRequest(
-            request.destinationDomain,
-            request.targetContract,
-            request.gasLimit,
-            request.minBlock,
-            request.callData,
-            request.requester
+            request.destinationDomain, request.targetContract, request.minBlock, request.callData, request.requester
         );
     }
 
     function _processReadRequest(
         uint32 destinationDomain,
         address targetContract,
-        uint256 gasLimit,
         uint64 minBlock,
         bytes calldata callData,
         address requester
@@ -126,8 +113,7 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
         );
 
         nonce++;
-        // `gasLimit` is emitted for the off-chain relayer only and otherwise unused.
-        emit ReadRequested(requestId, destinationDomain, targetContract, requester, gasLimit, minBlock, callData, nonce);
+        emit ReadRequested(requestId, destinationDomain, targetContract, requester, minBlock, callData, nonce);
     }
 
     /**
@@ -136,8 +122,7 @@ contract T1XChainReader is ReentrancyGuardUpgradeable {
      * @param batchIndex The batch index of the read request
      * @param newRoot The root of the proof of read merkle tree
      */
-    function commitProofOfReadRoot(uint256 batchIndex, bytes32 newRoot) external payable onlyProver {
-        if (msg.value != 0) revert EtherNotAccepted();
+    function commitProofOfReadRoot(uint256 batchIndex, bytes32 newRoot) external onlyProver {
         if (batchIndex > nextBatchIndex) revert InvalidBatchIndex();
         proofOfReadRoots[batchIndex] = newRoot;
         nextBatchIndex++;

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -303,7 +303,7 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
         vm.stopPrank();
 
         vm.startPrank(vegeta);
-        bytes32 requestId_ = l1T1ERC7683.verifySettlement(destination, 1_000_000, orderId_);
+        bytes32 requestId_ = l1T1ERC7683.verifySettlement(destination, orderId_);
         vm.stopPrank();
 
         return (orderData, orderId_, requestId_);


### PR DESCRIPTION
Removes gasLimits, payable, and introduces upgradability back to T1XChainReader

## Description

- Restored owner functionality and simplified cross-chain read events in T1XChainReader by removing the gas limit parameter and ETH checks
- Updated T1ERC7683 to match the new reader interface, eliminating the gas limit argument in verifySettlement
- Adjusted tests to use the streamlined settlement verification call without a gas limit parameter
- Modified settlement scripts accordingly, ensuring they invoke verifySettlement with only destination and orderId

## Motivation and Context

Addresses post merge comments from https://github.com/t1protocol/t1/pull/122

## How Has This Been Tested?

unit tests


## Types of changes (remove all unchecked types)

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [x] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:


-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.