### PR TITLE
fix: emit ReadRequested before incrementing nonce

### DIFF
--- a/contracts/src/libraries/xChain/T1XChainReader.sol
+++ b/contracts/src/libraries/xChain/T1XChainReader.sol
@@ -112,8 +112,8 @@ contract T1XChainReader is OwnableUpgradeable, ReentrancyGuardUpgradeable {
             )
         );
 
-        nonce++;
         emit ReadRequested(requestId, destinationDomain, targetContract, requester, minBlock, callData, nonce);
+        nonce++;
     }
 
     /**

--- a/contracts/src/test/7683/T1XChainReaderTest.t.sol
+++ b/contracts/src/test/7683/T1XChainReaderTest.t.sol
@@ -263,6 +263,47 @@ contract T1XChainReaderTest is T1BasicSwapE2E {
         originReader.commitProofOfReadRoot(batchIndex, root);
     }
 
+    function test_requestReadEmitsCorrectNonce() public {
+        T1XChainReader.ReadRequest memory request = T1XChainReader.ReadRequest({
+            destinationDomain: destination,
+            targetContract: address(0xbeef),
+            minBlock: 0,
+            callData: hex"",
+            requester: address(this)
+        });
+
+        vm.warp(100);
+
+        uint256 expectedNonce = originReader.nonce();
+        bytes32 expectedRequestId = keccak256(
+            abi.encodePacked(
+                block.chainid,
+                request.destinationDomain,
+                request.targetContract,
+                request.callData,
+                block.timestamp,
+                request.requester,
+                expectedNonce
+            )
+        );
+
+        vm.expectEmit(true, true, true, true);
+        emit T1XChainReader.ReadRequested(
+            expectedRequestId,
+            request.destinationDomain,
+            request.targetContract,
+            request.requester,
+            request.minBlock,
+            request.callData,
+            expectedNonce
+        );
+
+        bytes32 requestId_ = originReader.requestRead(request);
+
+        assertEq(requestId_, expectedRequestId, "requestId mismatch");
+        assertEq(originReader.nonce(), expectedNonce + 1, "nonce should increment");
+    }
+
     // function test_ownerCanUpdateProver() public {
     //     address newProver = address(0xbeef);
     //     originReader.setProver(newProver);


### PR DESCRIPTION
emit ReadRequested before incrementing nonce

## Description

Updated the nonce handling in the request processing logic so that the emitted event reflects the current nonce before incrementing

Added a regression test ensuring that the first ReadRequested event contains nonce zero and that the nonce increments afterward

## Motivation and Context

The merkle tree on the relayer side was corrupted due to this bug.

## How Has This Been Tested?

unit tests


## Types of changes (remove all unchecked types)


-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.