### PR TITLE
Feat/enforce auction winner

### DIFF
--- a/contracts/src/7683/BasicSwap7683.sol
+++ b/contracts/src/7683/BasicSwap7683.sol
@@ -71,6 +71,7 @@ abstract contract BasicSwap7683 is Base7683 {
     error InvalidOrderDomain();
     error InvalidDomain();
     error InvalidSender();
+    error InvalidSolver(address enforcedSolver);
 
     // ============ Modifiers ============
 
@@ -121,7 +122,7 @@ abstract contract BasicSwap7683 is Base7683 {
         uint32 _messageOrigin,
         bytes32 _messageSender,
         bytes32 _orderId,
-        address _receiver
+        bytes32 _receiver
     )
         internal
         virtual
@@ -132,11 +133,12 @@ abstract contract BasicSwap7683 is Base7683 {
 
         orderStatus[_orderId] = SETTLED;
 
+        address receiver = TypeCasts.bytes32ToAddress(_receiver);
         address inputToken = TypeCasts.bytes32ToAddress(orderData.inputToken);
 
-        _transferTokenOut(inputToken, _receiver, orderData.amountIn);
+        _transferTokenOut(inputToken, receiver, orderData.amountIn);
 
-        emit Settled(_orderId, _receiver);
+        emit Settled(_orderId, receiver);
     }
 
     /**
@@ -371,6 +373,11 @@ abstract contract BasicSwap7683 is Base7683 {
         if (_orderId != OrderEncoder.id(orderData)) revert InvalidOrderId();
         if (block.timestamp > orderData.fillDeadline) revert OrderFillExpired();
         if (orderData.destinationDomain != _localDomain()) revert InvalidOrderDomain();
+        // Enforce auction winner
+        if (orderData.data.length > 0) {
+            address enforcedSolver = abi.decode(orderData.data, (address));
+            if (msg.sender != enforcedSolver) revert InvalidSolver(enforcedSolver);
+        }
 
         address outputToken = TypeCasts.bytes32ToAddress(orderData.outputToken);
         address recipient = TypeCasts.bytes32ToAddress(orderData.recipient);

--- a/contracts/src/7683/BasicSwap7683.sol
+++ b/contracts/src/7683/BasicSwap7683.sol
@@ -121,7 +121,7 @@ abstract contract BasicSwap7683 is Base7683 {
         uint32 _messageOrigin,
         bytes32 _messageSender,
         bytes32 _orderId,
-        bytes32 _receiver
+        address _receiver
     )
         internal
         virtual
@@ -132,12 +132,11 @@ abstract contract BasicSwap7683 is Base7683 {
 
         orderStatus[_orderId] = SETTLED;
 
-        address receiver = TypeCasts.bytes32ToAddress(_receiver);
         address inputToken = TypeCasts.bytes32ToAddress(orderData.inputToken);
 
-        _transferTokenOut(inputToken, receiver, orderData.amountIn);
+        _transferTokenOut(inputToken, _receiver, orderData.amountIn);
 
-        emit Settled(_orderId, receiver);
+        emit Settled(_orderId, _receiver);
     }
 
     /**

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -70,7 +70,6 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
     error InvalidRequest();
     error InvalidOrder();
     error OrderFillNotExpired();
-    error InvalidSolver(address enforcedSolver);
 
     /// @notice Initializes the contract with the specified dependencies
     /// @param _permit2 The address of the permit2 contract
@@ -226,16 +225,12 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
 
             for (uint256 i = 0; i < _orderIds.length; i++) {
                 if (_settle) {
-                    address receiver = TypeCasts.bytes32ToAddress(abi.decode(_ordersFillerData[i], (bytes32)));
-
-                    // Enforce auction winner
-                    if (orderData.data.length > 0) {
-                        address enforcedSolver = abi.decode(orderData.data, (address));
-                        if (receiver != enforcedSolver) revert InvalidSolver(enforcedSolver);
-                    }
-
+                    // abi.decode(_ordersFillerData[i], (bytes32)) is receiver address set by solver when fill on dst
                     _handleSettleOrder(
-                        orderData.destinationDomain, orderData.destinationSettler, _orderIds[i], receiver
+                        orderData.destinationDomain,
+                        orderData.destinationSettler,
+                        _orderIds[i],
+                        abi.decode(_ordersFillerData[i], (bytes32))
                     );
                 }
             }

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -70,6 +70,7 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
     error InvalidRequest();
     error InvalidOrder();
     error OrderFillNotExpired();
+    error InvalidSolver(address enforcedSolver);
 
     /// @notice Initializes the contract with the specified dependencies
     /// @param _permit2 The address of the permit2 contract
@@ -218,28 +219,29 @@ contract T1ERC7683 is BasicSwap7683, OwnableUpgradeable, PausableUpgradeable {
             (, bytes memory _orderData) = abi.decode(openOrders[orderId], (bytes32, bytes));
             OrderData memory orderData = OrderEncoder.decode(_orderData);
 
-            _handle(orderData.destinationDomain, orderData.destinationSettler, result);
+            // Remove the first 32 bytes prefix of the message
+            bytes memory _innerMessage = abi.decode(result, (bytes));
+            (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
+                abi.decode(_innerMessage, (bool, bytes32[], bytes[]));
+
+            for (uint256 i = 0; i < _orderIds.length; i++) {
+                if (_settle) {
+                    address receiver = TypeCasts.bytes32ToAddress(abi.decode(_ordersFillerData[i], (bytes32)));
+
+                    // Enforce auction winner
+                    if (orderData.data.length > 0) {
+                        address enforcedSolver = abi.decode(orderData.data, (address));
+                        if (receiver != enforcedSolver) revert InvalidSolver(enforcedSolver);
+                    }
+
+                    _handleSettleOrder(
+                        orderData.destinationDomain, orderData.destinationSettler, _orderIds[i], receiver
+                    );
+                }
+            }
         }
 
         emit SettlementVerified(orderId, isSettled);
-    }
-
-    /// @notice Handles incoming messages
-    /// @dev Decodes the message and processes settlement or refund operations accordingly
-    /// @param _originDomain The domain from which the message originates
-    /// @param _sender The address of the sender on the origin domain
-    /// @param _message The encoded message received via t1
-    function _handle(uint32 _originDomain, bytes32 _sender, bytes memory _message) internal {
-        // Remove the first 32 bytes prefix of the message
-        bytes memory _innerMessage = abi.decode(_message, (bytes));
-        (bool _settle, bytes32[] memory _orderIds, bytes[] memory _ordersFillerData) =
-            abi.decode(_innerMessage, (bool, bytes32[], bytes[]));
-
-        for (uint256 i = 0; i < _orderIds.length; i++) {
-            if (_settle) {
-                _handleSettleOrder(_originDomain, _sender, _orderIds[i], abi.decode(_ordersFillerData[i], (bytes32)));
-            }
-        }
     }
 
     /// @notice Retrieves the local domain identifier.

--- a/contracts/src/test/7683/EnforceAuctionWinnerTest.t.sol
+++ b/contracts/src/test/7683/EnforceAuctionWinnerTest.t.sol
@@ -13,12 +13,13 @@ import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
 contract EnforceAuctionWinnerTest is T1XChainReaderBaseTestSetup {
     using TypeCasts for address;
 
+    uint256 batchIndex = 0;
+    uint256 position = 0;
     address solver;
 
     function setUp() public virtual override {
         super.setUp();
 
-        // Deploy T1XChainReader on both chains
         originReader = T1XChainReader(payable(_deployProxy(address(proxyOwner))));
         admin.upgrade(ITransparentUpgradeableProxy(address(originReader)), address(new T1XChainReader(address(this))));
         originReader.initialize(address(this));
@@ -43,96 +44,8 @@ contract EnforceAuctionWinnerTest is T1XChainReaderBaseTestSetup {
         l2T1ERC7683.initialize(address(l1T1ERC7683));
     }
 
-    function test_shouldSettleWithCorrectSolver() public {
-        uint256 batchIndex = 0;
-        uint256 position = 0;
-
+    function test_shouldFillWithCorrectSolver() public {
         solver = vegeta;
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
-        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
-
-        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-        // address(this) is prover
-        originReader.commitProofOfReadRoot(batchIndex, root);
-        vm.prank(vegeta);
-        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
-        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-        assertEq(
-            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
-        );
-
-        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
-    }
-
-    function test_shouldSettleWithCorrectSolverButOtherCaller() public {
-        uint256 batchIndex = 0;
-        uint256 position = 0;
-
-        solver = vegeta;
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
-        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
-
-        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-        // address(this) is prover
-        originReader.commitProofOfReadRoot(batchIndex, root);
-        vm.prank(kakaroto);
-        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
-        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-        assertEq(
-            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
-        );
-
-        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
-    }
-
-    function test_shouldSettleIfNoEnforcedSolver() public {
-        uint256 batchIndex = 0;
-        uint256 position = 0;
-
-        solver = address(0);
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
-        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
-
-        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
-        // address(this) is prover
-        originReader.commitProofOfReadRoot(batchIndex, root);
-        vm.prank(vegeta);
-        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
-        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
-
-        assertEq(
-            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
-        );
-
-        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
-    }
-
-    function test_shouldRevertWithIncorrectSolver() public {
-        uint256 batchIndex = 0;
-        uint256 position = 0;
-
-        solver = makeAddr("solver");
-        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
-
-        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
-        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
-
-        // address(this) is prover
-        originReader.commitProofOfReadRoot(batchIndex, root);
-        vm.prank(vegeta);
-        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidSolver.selector, solver));
-        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
-    }
-
-    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
         OrderData memory orderData = _prepareOrderData();
         if (solver != address(0)) {
             orderData.data = abi.encode(solver);
@@ -157,83 +70,63 @@ contract EnforceAuctionWinnerTest is T1XChainReaderBaseTestSetup {
         l2T1ERC7683.fill(orderId_, originData, fillerData);
         assertEq(l2T1ERC7683.orderStatus(orderId_), l2T1ERC7683.FILLED());
         vm.stopPrank();
+    }
 
-        vm.startPrank(vegeta);
-        bytes32 requestId_ = l1T1ERC7683.verifySettlement(destination, orderId_);
+    function test_shouldFillIfNoEnforcedSolver() public {
+        solver = address(0);
+        OrderData memory orderData = _prepareOrderData();
+        if (solver != address(0)) {
+            orderData.data = abi.encode(solver);
+        }
+
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(l1T1ERC7683), amount);
+        vm.recordLogs();
+        l1T1ERC7683.open(order);
         vm.stopPrank();
 
-        return (orderData, orderId_, requestId_);
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(l1T1ERC7683.orderStatus(orderId_), l1T1ERC7683.OPENED());
+
+        vm.startPrank(vegeta);
+        outputToken.approve(address(l2T1ERC7683), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        l2T1ERC7683.fill(orderId_, originData, fillerData);
+        assertEq(l2T1ERC7683.orderStatus(orderId_), l2T1ERC7683.FILLED());
+        vm.stopPrank();
     }
 
-    /// @dev Generate a merkle tree with depth 2 (4 leaves) including the result value and a proof
-    /// @param requestId Proof of read request id
-    /// @param result Result of the read
-    /// @param position position of the leaf where result is stored (0-3)
-    /// @return root Root of the merkle tree
-    /// @return proof Proof of for the leaf where result is stored
-    function _generateMerkleTree(
-        bytes32 requestId,
-        bytes memory result,
-        uint256 position
-    )
-        private
-        pure
-        returns (bytes32 root, bytes memory proof)
-    {
-        require(position < 4, "position must be < 4 for depth 2 tree");
-
-        // Generate 4 leaves, one for the result and three for the mock leaves
-        bytes32[] memory leafs = new bytes32[](4);
-        for (uint256 i = 0; i < leafs.length; i++) {
-            if (i == position) {
-                bytes32 xChainReadResultHash = keccak256(result);
-                // Use abi.encodePacked to match T1ERC7683.sol line 138
-                leafs[i] = keccak256(abi.encodePacked(xChainReadResultHash, requestId));
-            } else {
-                bytes32 mockLeaf = keccak256(abi.encodePacked("mock_leaf", i));
-                leafs[i] = mockLeaf;
-            }
+    function test_shouldRevertWithIncorrectSolver() public {
+        solver = makeAddr("solver");
+        OrderData memory orderData = _prepareOrderData();
+        if (solver != address(0)) {
+            orderData.data = abi.encode(solver);
         }
 
-        // Build intermediate nodes
-        bytes32[] memory level1 = new bytes32[](2);
-        level1[0] = _efficientHash(leafs[0], leafs[1]);
-        level1[1] = _efficientHash(leafs[2], leafs[3]);
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
 
-        root = _efficientHash(level1[0], level1[1]);
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(l1T1ERC7683), amount);
+        vm.recordLogs();
+        l1T1ERC7683.open(order);
+        vm.stopPrank();
 
-        // Generate proof for the target leaf at position position
-        bytes32[] memory proofElements = new bytes32[](2);
-        uint256 currentposition = position;
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(l1T1ERC7683.orderStatus(orderId_), l1T1ERC7683.OPENED());
 
-        // Leaf sibling
-        if (currentposition % 2 == 0) {
-            proofElements[0] = leafs[currentposition + 1];
-        } else {
-            proofElements[0] = leafs[currentposition - 1];
-        }
-        currentposition /= 2;
+        vm.startPrank(vegeta);
+        outputToken.approve(address(l2T1ERC7683), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
 
-        // Intermediate node sibling
-        if (currentposition % 2 == 0) {
-            proofElements[1] = level1[currentposition + 1];
-        } else {
-            proofElements[1] = level1[currentposition - 1];
-        }
-
-        // Encode proof as concatenated bytes32 values (WithdrawTrieVerifier expects this format)
-        proof = new bytes(64); // 2 * 32 bytes
-        assembly {
-            mstore(add(proof, 0x20), mload(add(proofElements, 0x20)))
-            mstore(add(proof, 0x40), mload(add(proofElements, 0x40)))
-        }
-    }
-
-    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
-        assembly {
-            mstore(0x00, a)
-            mstore(0x20, b)
-            value := keccak256(0x00, 0x40)
-        }
+        vm.expectRevert();
+        // vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidSolver.selector, solver));
+        l2T1ERC7683.fill(orderId_, originData, fillerData);
+        vm.stopPrank();
     }
 }

--- a/contracts/src/test/7683/EnforceAuctionWinnerTest.t.sol
+++ b/contracts/src/test/7683/EnforceAuctionWinnerTest.t.sol
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
+
+import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
+import { T1XChainReaderBaseTestSetup } from "./T1XChainReaderBaseTestSetup.sol";
+import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
+
+contract EnforceAuctionWinnerTest is T1XChainReaderBaseTestSetup {
+    using TypeCasts for address;
+
+    address solver;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy T1XChainReader on both chains
+        originReader = T1XChainReader(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(ITransparentUpgradeableProxy(address(originReader)), address(new T1XChainReader(address(this))));
+        originReader.initialize(address(this));
+
+        destinationReader = T1XChainReader(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(destinationReader)), address(new T1XChainReader(address(this)))
+        );
+        destinationReader.initialize(address(this));
+
+        l1T1ERC7683 = T1ERC7683(payable(_deployProxy(address(proxyOwner))));
+        l2T1ERC7683 = T1ERC7683(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(l1T1ERC7683)),
+            address(new T1ERC7683(address(0), address(originReader), uint32(origin)))
+        );
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(l2T1ERC7683)),
+            address(new T1ERC7683(address(0), address(destinationReader), uint32(destination)))
+        );
+        l1T1ERC7683.initialize(address(l2T1ERC7683));
+        l2T1ERC7683.initialize(address(l1T1ERC7683));
+    }
+
+    function test_shouldSettleWithCorrectSolver() public {
+        uint256 batchIndex = 0;
+        uint256 position = 0;
+
+        solver = vegeta;
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+        // address(this) is prover
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        vm.prank(vegeta);
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+        assertEq(
+            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+        );
+
+        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
+    }
+
+    function test_shouldSettleWithCorrectSolverButOtherCaller() public {
+        uint256 batchIndex = 0;
+        uint256 position = 0;
+
+        solver = vegeta;
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+        // address(this) is prover
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        vm.prank(kakaroto);
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+        assertEq(
+            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+        );
+
+        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
+    }
+
+    function test_shouldSettleIfNoEnforcedSolver() public {
+        uint256 batchIndex = 0;
+        uint256 position = 0;
+
+        solver = address(0);
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+        // address(this) is prover
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        vm.prank(vegeta);
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+        assertEq(
+            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+        );
+
+        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
+    }
+
+    function test_shouldRevertWithIncorrectSolver() public {
+        uint256 batchIndex = 0;
+        uint256 position = 0;
+
+        solver = makeAddr("solver");
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        // address(this) is prover
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        vm.prank(vegeta);
+        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidSolver.selector, solver));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+    }
+
+    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+        OrderData memory orderData = _prepareOrderData();
+        if (solver != address(0)) {
+            orderData.data = abi.encode(solver);
+        }
+
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(l1T1ERC7683), amount);
+        vm.recordLogs();
+        l1T1ERC7683.open(order);
+        vm.stopPrank();
+
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(l1T1ERC7683.orderStatus(orderId_), l1T1ERC7683.OPENED());
+
+        vm.startPrank(vegeta);
+        outputToken.approve(address(l2T1ERC7683), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(TypeCasts.addressToBytes32(vegeta));
+        l2T1ERC7683.fill(orderId_, originData, fillerData);
+        assertEq(l2T1ERC7683.orderStatus(orderId_), l2T1ERC7683.FILLED());
+        vm.stopPrank();
+
+        vm.startPrank(vegeta);
+        bytes32 requestId_ = l1T1ERC7683.verifySettlement(destination, orderId_);
+        vm.stopPrank();
+
+        return (orderData, orderId_, requestId_);
+    }
+
+    /// @dev Generate a merkle tree with depth 2 (4 leaves) including the result value and a proof
+    /// @param requestId Proof of read request id
+    /// @param result Result of the read
+    /// @param position position of the leaf where result is stored (0-3)
+    /// @return root Root of the merkle tree
+    /// @return proof Proof of for the leaf where result is stored
+    function _generateMerkleTree(
+        bytes32 requestId,
+        bytes memory result,
+        uint256 position
+    )
+        private
+        pure
+        returns (bytes32 root, bytes memory proof)
+    {
+        require(position < 4, "position must be < 4 for depth 2 tree");
+
+        // Generate 4 leaves, one for the result and three for the mock leaves
+        bytes32[] memory leafs = new bytes32[](4);
+        for (uint256 i = 0; i < leafs.length; i++) {
+            if (i == position) {
+                bytes32 xChainReadResultHash = keccak256(result);
+                // Use abi.encodePacked to match T1ERC7683.sol line 138
+                leafs[i] = keccak256(abi.encodePacked(xChainReadResultHash, requestId));
+            } else {
+                bytes32 mockLeaf = keccak256(abi.encodePacked("mock_leaf", i));
+                leafs[i] = mockLeaf;
+            }
+        }
+
+        // Build intermediate nodes
+        bytes32[] memory level1 = new bytes32[](2);
+        level1[0] = _efficientHash(leafs[0], leafs[1]);
+        level1[1] = _efficientHash(leafs[2], leafs[3]);
+
+        root = _efficientHash(level1[0], level1[1]);
+
+        // Generate proof for the target leaf at position position
+        bytes32[] memory proofElements = new bytes32[](2);
+        uint256 currentposition = position;
+
+        // Leaf sibling
+        if (currentposition % 2 == 0) {
+            proofElements[0] = leafs[currentposition + 1];
+        } else {
+            proofElements[0] = leafs[currentposition - 1];
+        }
+        currentposition /= 2;
+
+        // Intermediate node sibling
+        if (currentposition % 2 == 0) {
+            proofElements[1] = level1[currentposition + 1];
+        } else {
+            proofElements[1] = level1[currentposition - 1];
+        }
+
+        // Encode proof as concatenated bytes32 values (WithdrawTrieVerifier expects this format)
+        proof = new bytes(64); // 2 * 32 bytes
+        assembly {
+            mstore(add(proof, 0x20), mload(add(proofElements, 0x20)))
+            mstore(add(proof, 0x40), mload(add(proofElements, 0x40)))
+        }
+    }
+
+    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+        assembly {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}


### PR DESCRIPTION
## Description

This PR add a check for the data in fillInstruction field to match with account doing the fill.
Used to ensure only the auction winner can fill the intent.
The contracts can still be used as usual, without specifying anything in that field and let the fill opened.

## Motivation and Context

We need a way to enforce the result of offchain auction.

## How Has This Been Tested?

Add a test suite specifically for this feature.

## Types of changes (remove all unchecked types)

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.