### PR TITLE
Feat/enforce auction winner v2

### DIFF
--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -47,6 +47,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 24 hours),
+            closedAuction: false,
             data: new bytes(0)
         });
 

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -47,6 +47,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 24 hours),
+            closedAuction: false,
             data: new bytes(0)
         });
 

--- a/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L1ToL2.s.sol
@@ -45,6 +45,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("L2_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 24 hours),
+            closedAuction: false,
             data: new bytes(0)
         });
 

--- a/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
+++ b/contracts/script/test/7683/T1ERC7683L2ToL1.s.sol
@@ -46,6 +46,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("L1_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 24 hours),
+            closedAuction: false,
             data: new bytes(0)
         });
 

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -24,6 +24,11 @@ import { IT1XChainReader } from "../libraries/xChain/IT1XChainReader.sol";
 contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
+    struct Bid {
+        address settlementReceiver;
+        uint256 amountOut;
+    }
+
     // ============ Constants ============
     uint32 public immutable localDomain;
     IT1XChainReader public immutable xChainRead;
@@ -37,6 +42,7 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     mapping(bytes32 => bytes32) public refundReadRequestToOrderId;
     /// @notice Maps order IDs to verification status
     mapping(bytes32 => bool) public orderVerified;
+    mapping(bytes32 orderId => Bid winnerBid) public orderToBid;
 
     // ============ Events ============
     /**
@@ -69,6 +75,7 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
      * @param receiver The address of the order's input token receiver.
      */
     event Refunded(bytes32 indexed orderId, address receiver);
+    event WinnerBidCommited(bytes32 indexed orderId, address indexed settlementSeceiver);
 
     // ============ Upgrade Gap ============
     /// @dev Reserved storage slots for upgradeability.
@@ -82,6 +89,9 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     error InvalidOrder();
     error OrderFillNotExpired();
     error NotEligible();
+    error InvalidFill(
+        address settlementReceiver, address expectedSettlementReceiver, uint256 amountOut, uint256 expectedAmountOut
+    );
 
     /// @notice Initializes the contract with the specified dependencies
     /// @param _permit2 The address of the permit2 contract
@@ -237,7 +247,20 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
 
             for (uint256 i = 0; i < _orderIds.length; i++) {
                 if (_settle) {
-                    (, address settlementReceiver) = abi.decode(_ordersFillerData[i], (uint256, address));
+                    (uint256 amountOut, address settlementReceiver) =
+                        abi.decode(_ordersFillerData[i], (uint256, address));
+                    Bid memory winnerBid = orderToBid[orderId];
+
+                    if (
+                        orderData.closedAuction == true
+                            && (settlementReceiver != winnerBid.settlementReceiver || amountOut != winnerBid.amountOut)
+                    ) {
+                        revert InvalidFill(
+                            settlementReceiver, winnerBid.settlementReceiver, amountOut, winnerBid.amountOut
+                        );
+                    }
+                    delete orderToBid[orderId];
+
                     _handleSettleOrder(
                         orderData.destinationDomain, orderData.destinationSettler, _orderIds[i], settlementReceiver
                     );
@@ -378,6 +401,11 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
 
             emit Refunded(orderId, orderSender);
         }
+    }
+
+    function commitWinnerBid(bytes32 orderId, Bid calldata winnerBid) external onlyOwner {
+        orderToBid[orderId] = winnerBid;
+        emit WinnerBidCommited(orderId, winnerBid.settlementReceiver);
     }
 
     function pause() external onlyOwner {

--- a/contracts/src/7683/T1ERC7683.sol
+++ b/contracts/src/7683/T1ERC7683.sol
@@ -24,6 +24,11 @@ import { IT1XChainReader } from "../libraries/xChain/IT1XChainReader.sol";
 contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
+    /**
+     * @notice Represents a bid for order settlement
+     * @param settlementReceiver The address that will receive the settlement on src chain
+     * @param amountOut The amount of output tokens to be received on dst chain
+     */
     struct Bid {
         address settlementReceiver;
         uint256 amountOut;
@@ -42,6 +47,7 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     mapping(bytes32 => bytes32) public refundReadRequestToOrderId;
     /// @notice Maps order IDs to verification status
     mapping(bytes32 => bool) public orderVerified;
+    /// @notice Maps order IDs to their winning bid information
     mapping(bytes32 orderId => Bid winnerBid) public orderToBid;
 
     // ============ Events ============
@@ -75,6 +81,11 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
      * @param receiver The address of the order's input token receiver.
      */
     event Refunded(bytes32 indexed orderId, address receiver);
+    /**
+     * @notice Emitted when a winner bid is committed for an order
+     * @param orderId The ID of the order
+     * @param settlementSeceiver The address of the settlement receiver
+     */
     event WinnerBidCommited(bytes32 indexed orderId, address indexed settlementSeceiver);
 
     // ============ Upgrade Gap ============
@@ -217,6 +228,7 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
     }
 
     /// @notice Use result of proof of read to handle the order depending on the result
+    /// Also enforce auction winner bid if the orderId has closed auction.
     /// @param encodedProofOfRead The encoded proof of read which is formatted as following:
     /// abi.encode(uint256 batchIndex, bytes32 requestId, uint256 position, bytes result, bytes proof)
     function handleReadResultWithProof(bytes calldata encodedProofOfRead) external {
@@ -403,6 +415,11 @@ contract T1ERC7683 is Base7683, OwnableUpgradeable, PausableUpgradeable {
         }
     }
 
+    /**
+     * @notice Commits a winning bid for a specific order
+     * @param orderId The ID of the order to set the winner bid for
+     * @param winnerBid The winning bid containing settlement receiver and amount out
+     */
     function commitWinnerBid(bytes32 orderId, Bid calldata winnerBid) external onlyOwner {
         orderToBid[orderId] = winnerBid;
         emit WinnerBidCommited(orderId, winnerBid.settlementReceiver);

--- a/contracts/src/libraries/7683/OrderEncoder.sol
+++ b/contracts/src/libraries/7683/OrderEncoder.sol
@@ -13,6 +13,7 @@ struct OrderData {
     uint32 destinationDomain;
     bytes32 destinationSettler;
     uint32 fillDeadline;
+    bool closedAuction;
     bytes data;
 }
 
@@ -30,6 +31,7 @@ library OrderEncoder {
         "uint32 destinationDomain,",
         "bytes32 destinationSettler,",
         "uint32 fillDeadline,",
+        "bool closedAuction,",
         "bytes data)"
     );
 

--- a/contracts/src/test/7683/ClosedAuctionTest.sol
+++ b/contracts/src/test/7683/ClosedAuctionTest.sol
@@ -1,0 +1,232 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
+import { ITransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { OrderData, OrderEncoder } from "../../../src/libraries/7683/OrderEncoder.sol";
+import { OnchainCrossChainOrder } from "../../../src/interfaces/IERC7683.sol";
+
+import { IT1XChainReader } from "../../libraries/xChain/IT1XChainReader.sol";
+import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
+import { T1XChainReaderBaseTestSetup } from "./T1XChainReaderBaseTestSetup.sol";
+import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
+import { Base7683 } from "../../7683/Base7683.sol";
+
+contract ClosedAuctionTest is T1XChainReaderBaseTestSetup {
+    using TypeCasts for address;
+
+    uint256 batchIndex = 0;
+    uint256 position = 0;
+
+    function setUp() public virtual override {
+        super.setUp();
+
+        // Deploy T1XChainReader on both chains
+        originReader = T1XChainReader(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(ITransparentUpgradeableProxy(address(originReader)), address(new T1XChainReader(address(this))));
+        originReader.initialize(address(this));
+
+        destinationReader = T1XChainReader(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(destinationReader)), address(new T1XChainReader(address(this)))
+        );
+        destinationReader.initialize(address(this));
+
+        l1T1ERC7683 = T1ERC7683(payable(_deployProxy(address(proxyOwner))));
+        l2T1ERC7683 = T1ERC7683(payable(_deployProxy(address(proxyOwner))));
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(l1T1ERC7683)),
+            address(new T1ERC7683(address(0), address(originReader), uint32(origin)))
+        );
+        admin.upgrade(
+            ITransparentUpgradeableProxy(address(l2T1ERC7683)),
+            address(new T1ERC7683(address(0), address(destinationReader), uint32(destination)))
+        );
+        l1T1ERC7683.initialize(address(l2T1ERC7683));
+        l2T1ERC7683.initialize(address(l1T1ERC7683));
+    }
+
+    function test_settleWithCorrectBid() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        l1T1ERC7683.commitWinnerBid(orderId, T1ERC7683.Bid({ settlementReceiver: vegeta, amountOut: amount }));
+
+        (address actualSettlementReceiver, uint256 actualAmountOut) = l1T1ERC7683.orderToBid(orderId);
+        assertEq(actualSettlementReceiver, vegeta);
+        assertEq(actualAmountOut, amount);
+
+        uint256 balanceSolverBeforeSettle = inputToken.balanceOf(address(vegeta));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+        uint256 balanceSolverAfterSettle = inputToken.balanceOf(address(vegeta));
+
+        assertEq(
+            balanceSolverBeforeSettle + amount, balanceSolverAfterSettle, "vegeta balance increased by input amount"
+        );
+
+        assertTrue(l1T1ERC7683.orderVerified(orderId), "Order should be verified");
+
+        (actualSettlementReceiver, actualAmountOut) = l1T1ERC7683.orderToBid(orderId);
+        assertEq(actualSettlementReceiver, address(0));
+        assertEq(actualAmountOut, 0);
+    }
+
+    function test_revertIfWinnerBidNotCommited() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        originReader.commitProofOfReadRoot(batchIndex, root);
+
+        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidFill.selector, vegeta, address(0), amount, 0));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+    }
+
+    function test_revertIfInvalidReceiver() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        l1T1ERC7683.commitWinnerBid(orderId, T1ERC7683.Bid({ settlementReceiver: kakaroto, amountOut: amount }));
+
+        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidFill.selector, vegeta, kakaroto, amount, amount));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+    }
+
+    function test_revertIfInvalidAmountOut() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        l1T1ERC7683.commitWinnerBid(orderId, T1ERC7683.Bid({ settlementReceiver: vegeta, amountOut: amount * 2 }));
+
+        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidFill.selector, vegeta, vegeta, amount, amount * 2));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+    }
+
+    function test_revertIfInvalidBid() public {
+        (, bytes32 orderId, bytes32 requestId) = _openAndFillOrder();
+        bytes memory result = abi.encode(l2T1ERC7683.getFilledOrderStatus(orderId));
+        (bytes32 root, bytes memory proof) = _generateMerkleTree(requestId, result, position);
+
+        originReader.commitProofOfReadRoot(batchIndex, root);
+        l1T1ERC7683.commitWinnerBid(orderId, T1ERC7683.Bid({ settlementReceiver: kakaroto, amountOut: amount * 2 }));
+
+        vm.expectRevert(abi.encodeWithSelector(T1ERC7683.InvalidFill.selector, vegeta, kakaroto, amount, amount * 2));
+        l1T1ERC7683.handleReadResultWithProof(abi.encode(batchIndex, requestId, position, result, proof));
+    }
+
+    function test_revertCommitIfNotOwner() public {
+        (, bytes32 orderId,) = _openAndFillOrder();
+
+        vm.prank(vegeta);
+        vm.expectRevert();
+        l1T1ERC7683.commitWinnerBid(orderId, T1ERC7683.Bid({ settlementReceiver: vegeta, amountOut: amount }));
+    }
+
+    function _openAndFillOrder() internal returns (OrderData memory, bytes32 orderId, bytes32 requestId) {
+        OrderData memory orderData = _prepareOrderData();
+        orderData.closedAuction = true;
+        OnchainCrossChainOrder memory order =
+            _prepareOnchainOrder(OrderEncoder.encode(orderData), orderData.fillDeadline, OrderEncoder.orderDataType());
+
+        vm.startPrank(kakaroto);
+        inputToken.approve(address(l1T1ERC7683), amount);
+        vm.recordLogs();
+        l1T1ERC7683.open(order);
+        vm.stopPrank();
+
+        (bytes32 orderId_,) = _getOrderIDFromLogs();
+        assertEq(l1T1ERC7683.orderStatus(orderId_), l1T1ERC7683.OPENED());
+
+        vm.startPrank(vegeta);
+        outputToken.approve(address(l2T1ERC7683), amount);
+        bytes memory originData = OrderEncoder.encode(orderData);
+        bytes memory fillerData = abi.encode(amount, TypeCasts.addressToBytes32(vegeta));
+        l2T1ERC7683.fill(orderId_, originData, fillerData);
+        assertEq(l2T1ERC7683.orderStatus(orderId_), l2T1ERC7683.FILLED());
+        vm.stopPrank();
+
+        vm.startPrank(vegeta);
+        bytes32 requestId_ = l1T1ERC7683.verifySettlement(destination, orderId_);
+        vm.stopPrank();
+
+        return (orderData, orderId_, requestId_);
+    }
+
+    /// @dev Generate a merkle tree with depth 2 (4 leaves) including the result value and a proof
+    /// @param requestId Proof of read request id
+    /// @param result Result of the read
+    /// @param position position of the leaf where result is stored (0-3)
+    /// @return root Root of the merkle tree
+    /// @return proof Proof of for the leaf where result is stored
+    function _generateMerkleTree(
+        bytes32 requestId,
+        bytes memory result,
+        uint256 position
+    )
+        private
+        pure
+        returns (bytes32 root, bytes memory proof)
+    {
+        require(position < 4, "position must be < 4 for depth 2 tree");
+
+        // Generate 4 leaves, one for the result and three for the mock leaves
+        bytes32[] memory leafs = new bytes32[](4);
+        for (uint256 i = 0; i < leafs.length; i++) {
+            if (i == position) {
+                bytes32 xChainReadResultHash = keccak256(result);
+                // Use abi.encodePacked to match T1ERC7683.sol line 138
+                leafs[i] = keccak256(abi.encodePacked(xChainReadResultHash, requestId));
+            } else {
+                bytes32 mockLeaf = keccak256(abi.encodePacked("mock_leaf", i));
+                leafs[i] = mockLeaf;
+            }
+        }
+
+        // Build intermediate nodes
+        bytes32[] memory level1 = new bytes32[](2);
+        level1[0] = _efficientHash(leafs[0], leafs[1]);
+        level1[1] = _efficientHash(leafs[2], leafs[3]);
+
+        root = _efficientHash(level1[0], level1[1]);
+
+        // Generate proof for the target leaf at position position
+        bytes32[] memory proofElements = new bytes32[](2);
+        uint256 currentposition = position;
+
+        // Leaf sibling
+        if (currentposition % 2 == 0) {
+            proofElements[0] = leafs[currentposition + 1];
+        } else {
+            proofElements[0] = leafs[currentposition - 1];
+        }
+        currentposition /= 2;
+
+        // Intermediate node sibling
+        if (currentposition % 2 == 0) {
+            proofElements[1] = level1[currentposition + 1];
+        } else {
+            proofElements[1] = level1[currentposition - 1];
+        }
+
+        // Encode proof as concatenated bytes32 values (WithdrawTrieVerifier expects this format)
+        proof = new bytes(64); // 2 * 32 bytes
+        assembly {
+            mstore(add(proof, 0x20), mload(add(proofElements, 0x20)))
+            mstore(add(proof, 0x40), mload(add(proofElements, 0x40)))
+        }
+    }
+
+    function _efficientHash(bytes32 a, bytes32 b) private pure returns (bytes32 value) {
+        assembly {
+            mstore(0x00, a)
+            mstore(0x20, b)
+            value := keccak256(0x00, 0x40)
+        }
+    }
+}

--- a/contracts/src/test/7683/RefundTest.t.sol
+++ b/contracts/src/test/7683/RefundTest.t.sol
@@ -54,6 +54,7 @@ contract RefundTest is BaseTest {
             destinationDomain: destination,
             destinationSettler: TypeCasts.addressToBytes32(counterpart),
             fillDeadline: FILL_DEADLINE_EXPIRED,
+            closedAuction: false,
             data: ""
         });
 

--- a/contracts/src/test/7683/T1XChainReaderBaseTestSetup.sol
+++ b/contracts/src/test/7683/T1XChainReaderBaseTestSetup.sol
@@ -64,6 +64,7 @@ contract T1XChainReaderBaseTestSetup is BaseTest {
             destinationDomain: destination,
             destinationSettler: address(l2T1ERC7683).addressToBytes32(),
             fillDeadline: uint32(block.timestamp + 100),
+            closedAuction: false,
             data: new bytes(0)
         });
     }

--- a/contracts/src/test/7683/TvlThresholdTest.t.sol
+++ b/contracts/src/test/7683/TvlThresholdTest.t.sol
@@ -173,6 +173,7 @@ contract TvlThresholdTest is BaseTest {
             destinationDomain: destination,
             destinationSettler: address(t1ERC7683).addressToBytes32(),
             fillDeadline: uint32(block.timestamp + 1 hours),
+            closedAuction: false,
             data: new bytes(0)
         });
     }


### PR DESCRIPTION
## Description

Add winner bid enforcement with a commit transaction sent from backend.

## Motivation and Context

We need to way to force solvers to respect the bid the commit to, after the open intent transaction has been done.

## How Has This Been Tested?

Test scripts.

## Types of changes (remove all unchecked types)

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.