### PR TITLE
fix: changed type of orderId in signature to what the contract expects

### DIFF
--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -123,7 +123,7 @@ contract SolverFillScript is Script {
 contract SettlementScript is Script {
     function run() external {
         vm.createSelectFork(vm.rpcUrl("arbitrum_sepolia"));
-        uint256 settlerPk = vm.envUint("ALICE_PRIVATE_KEY");
+        uint256 settlerPk = vm.envUint("TEST_PRIVATE_KEY");
 
         vm.startBroadcast(settlerPk);
 

--- a/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
+++ b/contracts/script/test/7683/T1ERC7683ArbToBase.s.sol
@@ -48,7 +48,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("BASE_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 5 minutes),
-            closedAuction: false,
+            closedAuction: true,
             data: new bytes(0)
         });
 

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -123,7 +123,7 @@ contract SolverFillScript is Script {
 contract SettlementScript is Script {
     function run() external {
         vm.createSelectFork(vm.rpcUrl("base_sepolia"));
-        uint256 settlerPk = vm.envUint("ALICE_PRIVATE_KEY");
+        uint256 settlerPk = vm.envUint("TEST_PRIVATE_KEY");
 
         vm.startBroadcast(settlerPk);
 

--- a/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
+++ b/contracts/script/test/7683/T1ERC7683BaseToArb.s.sol
@@ -48,7 +48,7 @@ contract AliceSetupScript is Script {
             destinationDomain: DESTINATION_CHAIN,
             destinationSettler: TypeCasts.addressToBytes32(vm.envAddress("ARB_T1_PULL_BASED_7683_PROXY_ADDR")),
             fillDeadline: uint32(block.timestamp + 5 minutes),
-            closedAuction: false,
+            closedAuction: true,
             data: new bytes(0)
         });
 

--- a/tee-apps/sealed-bid-auction/script/server.ts
+++ b/tee-apps/sealed-bid-auction/script/server.ts
@@ -12,6 +12,8 @@ import {BlockchainClient} from "../src/blockchain/BlockchainClient.ts";
 const USE_TLS = process.env.USE_TLS as string === "true";
 const SOLVER_PRICE_TTL_SECONDS = process.env.SOLVER_PRICE_TTL_SECONDS
 const TEN_MINUTES_IN_SECONDS = 600;
+const BASE_T1_ERC_7683_CONTRACT_ADDRESS = process.env.BASE_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`;
+const ARBITRUM_T1_ERC_7683_CONTRACT_ADDRESS = process.env.ARBITRUM_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`;
 
 const solverPriceBook = new SolverPriceBook(SOLVER_PRICE_TTL_SECONDS ? Number(SOLVER_PRICE_TTL_SECONDS as string) : TEN_MINUTES_IN_SECONDS);
 const auctionService = new AuctionService(solverPriceBook);
@@ -31,17 +33,19 @@ const baseClient = new BlockchainClient(
 );
 const arbitrumSepoliaIntentObserver = new ViemIntentObserver(
     arbitrumClient,
-    process.env.ARBITRUM_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`,
+    ARBITRUM_T1_ERC_7683_CONTRACT_ADDRESS,
     auctionService,
     httpServer,
-    baseClient.publicClient.chain.id
+    baseClient.publicClient.chain.id,
+    BASE_T1_ERC_7683_CONTRACT_ADDRESS
 );
 const baseSepoliaIntentObserver = new ViemIntentObserver(
     baseClient,
-    process.env.BASE_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`,
+    BASE_T1_ERC_7683_CONTRACT_ADDRESS,
     auctionService,
     httpServer,
-    arbitrumClient.publicClient.chain.id
+    arbitrumClient.publicClient.chain.id,
+    ARBITRUM_T1_ERC_7683_CONTRACT_ADDRESS
 );
 
 async function main() {

--- a/tee-apps/sealed-bid-auction/script/server.ts
+++ b/tee-apps/sealed-bid-auction/script/server.ts
@@ -33,13 +33,15 @@ const arbitrumSepoliaIntentObserver = new ViemIntentObserver(
     arbitrumClient,
     process.env.ARBITRUM_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`,
     auctionService,
-    httpServer
+    httpServer,
+    baseClient.publicClient.chain.id
 );
 const baseSepoliaIntentObserver = new ViemIntentObserver(
     baseClient,
     process.env.BASE_T1_ERC7683_CONTRACT_ADDRESS as `0x${string}`,
     auctionService,
-    httpServer
+    httpServer,
+    arbitrumClient.publicClient.chain.id
 );
 
 async function main() {

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -1,6 +1,6 @@
 import {
-  decodeAbiParameters, pad,
-  parseEventLogs, toHex,
+  decodeAbiParameters,
+  parseEventLogs,
   trim,
   type WatchEventOnLogsParameter,
 } from "viem";
@@ -109,7 +109,7 @@ export class ViemIntentObserver {
           amountOut: winningPrice.amountOut,
           orderId,
           signature: await this.signAuctionResult(
-            BigInt(orderId),
+            orderId,
             winningPrice.settlementReceiverAddress as `0x${string}`,
             winningPrice.amountOut
           ),
@@ -133,9 +133,9 @@ export class ViemIntentObserver {
   }
 
   private async signAuctionResult(
-    orderId: bigint,
-    winningSolver: `0x${string}`,
-    amountOut: bigint
+      orderId: `0x${string}`,
+      winningSolver: `0x${string}`,
+      amountOut: bigint
   ): Promise<string> {
     const domain = {
       name: "T1ERC7683",
@@ -154,15 +154,11 @@ export class ViemIntentObserver {
     this.logger.debug(`Types of signed properties: orderId=[${typeof orderId}] filler=[${typeof winningSolver}] amountOut=[${typeof amountOut}]`);
 
     const message = {
-      orderId: this.toBytes32OrderId(orderId),
+      orderId,
       filler: winningSolver,
       amountOut,
     };
 
     return await this.blockchainClient.signTypedData(domain, types, message);
-  }
-
-  private toBytes32OrderId(orderId: bigint | number): `0x${string}` {
-    return pad(toHex(orderId, { size: 32 }), { size: 32 });
   }
 }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -24,6 +24,7 @@ export class ViemIntentObserver {
     private readonly t1Erc7683ContractAddress: `0x${string}`,
     private readonly auctionService: AuctionService,
     private readonly apiServer: AuctionApiServer,
+    private readonly destinationChainId: number,
     private readonly auctionPollingInterval: number = 500
   ) {
     this.logger = new WinstonLogger(
@@ -140,7 +141,7 @@ export class ViemIntentObserver {
     const domain = {
       name: "T1ERC7683",
       version: "1",
-      chainId: BigInt(this.blockchainClient.publicClient.chain.id),
+      chainId: BigInt(this.destinationChainId),
       verifyingContract: this.t1Erc7683ContractAddress,
     };
 

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -20,27 +20,28 @@ export class ViemIntentObserver {
   private logger: WinstonLogger;
 
   constructor(
-    private readonly blockchainClient: BlockchainClient,
-    private readonly t1Erc7683ContractAddress: `0x${string}`,
+    private readonly sourceChainClient: BlockchainClient,
+    private readonly sourceChainT1Erc7683ContractAddress: `0x${string}`,
     private readonly auctionService: AuctionService,
     private readonly apiServer: AuctionApiServer,
     private readonly destinationChainId: number,
+    private readonly destinationChainT1Erc7683ContractAddress: `0x${string}`,
     private readonly auctionPollingInterval: number = 500
   ) {
     this.logger = new WinstonLogger(
-      `${ViemIntentObserver.name}[${this.blockchainClient.publicClient.chain.name}]`
+      `${ViemIntentObserver.name}[${this.sourceChainClient.publicClient.chain.name}]`
     );
   }
 
   public start() {
-    this.blockchainClient.publicClient.watchEvent({
-      address: this.t1Erc7683ContractAddress,
+    this.sourceChainClient.publicClient.watchEvent({
+      address: this.sourceChainT1Erc7683ContractAddress,
       event: OPEN_INTENT_ABI_EVENT,
       onLogs: (logs) => this.processIntentLogs(logs),
     });
 
     this.logger.info(
-      `Watching for Open Intent events on chain [${this.blockchainClient.publicClient.chain.name}] and contract [${this.t1Erc7683ContractAddress}]`
+      `Watching for Open Intent events on chain [${this.sourceChainClient.publicClient.chain.name}] and contract [${this.sourceChainT1Erc7683ContractAddress}]`
     );
   }
 
@@ -85,7 +86,7 @@ export class ViemIntentObserver {
 
   private async runAuctionAndNotifySolver(
     orderData: OrderData,
-    orderId: string
+    orderId: `0x${string}`
   ) {
     this.logger.info(`Running auction for order ${orderId}`);
 
@@ -118,7 +119,7 @@ export class ViemIntentObserver {
 
         await this.apiServer.notifySolvers(
           result,
-          this.blockchainClient.publicClient.chain.id
+          this.sourceChainClient.publicClient.chain.id
         );
 
         this.logger.info(
@@ -142,7 +143,7 @@ export class ViemIntentObserver {
       name: "T1ERC7683",
       version: "1",
       chainId: this.destinationChainId,
-      verifyingContract: this.t1Erc7683ContractAddress,
+      verifyingContract: this.destinationChainT1Erc7683ContractAddress,
     };
 
     const types = {
@@ -161,6 +162,6 @@ export class ViemIntentObserver {
       amountOut,
     };
 
-    return await this.blockchainClient.signTypedData(domain, types, message);
+    return await this.sourceChainClient.signTypedData(domain, types, message);
   }
 }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -152,6 +152,7 @@ export class ViemIntentObserver {
       ],
     };
     this.logger.debug(`Types of signed properties: orderId=[${typeof orderId}] filler=[${typeof winningSolver}] amountOut=[${typeof amountOut}]`);
+    this.logger.debug(`Values of signed properties: orderId=[${orderId}] filler=[${winningSolver}] amountOut=[${amountOut}]`);
 
     const message = {
       orderId,

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -141,7 +141,7 @@ export class ViemIntentObserver {
     const domain = {
       name: "T1ERC7683",
       version: "1",
-      chainId: BigInt(this.destinationChainId),
+      chainId: this.destinationChainId,
       verifyingContract: this.t1Erc7683ContractAddress,
     };
 

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -1,6 +1,6 @@
 import {
-  decodeAbiParameters,
-  parseEventLogs,
+  decodeAbiParameters, pad,
+  parseEventLogs, toHex,
   trim,
   type WatchEventOnLogsParameter,
 } from "viem";
@@ -146,7 +146,7 @@ export class ViemIntentObserver {
 
     const types = {
       FillAuthorization: [
-        { name: "orderId", type: "uint256" },
+        { name: "orderId", type: "bytes32" },
         { name: "filler", type: "address" },
         { name: "amountOut", type: "uint256" },
       ],
@@ -154,11 +154,15 @@ export class ViemIntentObserver {
     this.logger.debug(`Types of signed properties: orderId=[${typeof orderId}] filler=[${typeof winningSolver}] amountOut=[${typeof amountOut}]`);
 
     const message = {
-      orderId,
+      orderId: this.toBytes32OrderId(orderId),
       filler: winningSolver,
       amountOut,
     };
 
     return await this.blockchainClient.signTypedData(domain, types, message);
+  }
+
+  private toBytes32OrderId(orderId: bigint | number): `0x${string}` {
+    return pad(toHex(orderId, { size: 32 }), { size: 32 });
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Another attempt at resolving a signature mismatch between Auction backend and T1ERC7683 contract.

Fix is :
- send `orderId` as a `bytes32` hex string rather than BigInt - which is what the contract expects.
- adjust `chainId` in domain header to be target chain id (was source)
- adjust `verifyingContractAddress` in domain header to be target chain contract (was source)
<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
on v07


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.