### PR TITLE
Fix: xYield withdraw from only callable by guardian

### DIFF
--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -269,11 +269,6 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         emit Withdraw(_caller, _receiver, _owner, _amount, _shares);
     }
 
-    function _setActiveChain(bool _isActive) internal {
-        isActiveChain = _isActive;
-        emit ChainStatusChanged(_isActive);
-    }
-
     function totalSupply() public view virtual override(ERC20, IERC20) returns (uint256) {
         return virtualTotalSupply;
     }
@@ -284,7 +279,8 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     }
 
     function setActiveChain(bool _isActive) external onlyGuardian {
-        _setActiveChain(_isActive);
+        isActiveChain = _isActive;
+        emit ChainStatusChanged(_isActive);
     }
 
     function setSiblingVault(uint64 _chainId, address _vault) external onlyOwner {
@@ -322,7 +318,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         if (_targetChain != orderData.destinationDomain) revert InvalidOrderData();
         if (_amount != orderData.amountIn) revert InvalidOrderData();
 
-        _setActiveChain(false);
+        isActiveChain = false;
 
         yieldProtocol.withdraw(_amount, address(this), address(this));
         updateVirtualTotalAssets();
@@ -342,7 +338,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         proofs[0] = proof;
         settler.refund(orders, proofs);
 
-        _setActiveChain(true);
+        isActiveChain = true;
         virtualTotalAssets = ERC20(asset()).balanceOf(address(this));
 
         (OrderData memory orderData) = abi.decode(order.orderData, (OrderData));

--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -260,6 +260,11 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         emit Withdraw(_caller, _receiver, _owner, _amount, _shares);
     }
 
+    function _setActiveChain(bool _isActive) internal {
+        isActiveChain = _isActive;
+        emit ChainStatusChanged(_isActive);
+    }
+
     function totalSupply() public view virtual override(ERC20, IERC20) returns (uint256) {
         return virtualTotalSupply;
     }
@@ -270,8 +275,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     }
 
     function setActiveChain(bool _isActive) external onlyGuardian {
-        isActiveChain = _isActive;
-        emit ChainStatusChanged(_isActive);
+        _setActiveChain(_isActive);
     }
 
     function setSiblingVault(uint64 _chainId, address _vault) external onlyOwner {
@@ -309,7 +313,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         if (_targetChain != orderData.destinationDomain) revert InvalidOrderData();
         if (_amount != orderData.amountIn) revert InvalidOrderData();
 
-        isActiveChain = false;
+        _setActiveChain(false);
 
         yieldProtocol.withdraw(_amount, address(this), address(this));
         updateVirtualTotalAssets();
@@ -329,7 +333,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         proofs[0] = proof;
         settler.refund(orders, proofs);
 
-        isActiveChain = true;
+        _setActiveChain(true);
         virtualTotalAssets = ERC20(asset()).balanceOf(address(this));
 
         (OrderData memory orderData) = abi.decode(order.orderData, (OrderData));

--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -166,7 +166,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         return assets;
     }
 
-    function withdrawFrom(uint256 assets, address owner, uint64 chainId) external nonReentrant returns (uint256) {
+    function withdrawFrom(uint256 assets, address owner, uint64 chainId) external nonReentrant onlyGuardian returns (uint256) {
         _withdrawFrom(owner, assets);
     }
 

--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -166,7 +166,16 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         return assets;
     }
 
-    function withdrawFrom(uint256 assets, address owner, uint64 chainId) external nonReentrant onlyGuardian returns (uint256) {
+    function withdrawFrom(
+        uint256 assets,
+        address owner,
+        uint64 chainId
+    )
+        external
+        nonReentrant
+        onlyGuardian
+        returns (uint256)
+    {
         _withdrawFrom(owner, assets);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add onlyGuardian modifier to `withdrawFrom`
<!--- Describe your changes in detail -->

## Motivation and Context
The remote withdrawal user has no share tokens on that chain, so we can only trust the guardian to withdraw the correct amount for the user.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
All existing tests passing.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.