### PR TITLE
Feat/xYield: impl request ID + Across callback method + install libusb in CI

### DIFF
--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -4,6 +4,12 @@ description: 'Install dependencies'
 runs:
   using: composite
   steps:
+    - name: Install system dependencies
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libudev-dev libusb-1.0-0-dev
+
     - name: Install Foundry
       uses: foundry-rs/foundry-toolchain@v1
 

--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -21,4 +21,4 @@ runs:
     - name: Install Node.js dependencies
       working-directory: contracts
       shell: bash
-      run: bun install
+      run: bun install --no-optional

--- a/.github/actions/install_dependencies/action.yaml
+++ b/.github/actions/install_dependencies/action.yaml
@@ -21,4 +21,4 @@ runs:
     - name: Install Node.js dependencies
       working-directory: contracts
       shell: bash
-      run: bun install --no-optional
+      run: bun install --ignore-scripts

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -38,6 +38,8 @@ jobs:
   build:
     name: build
     runs-on: "ubuntu-latest"
+    env:
+      FOUNDRY_PROFILE: "via_ir"
     steps:
       - name: "Check out the repo"
         uses: "actions/checkout@v4"
@@ -59,6 +61,7 @@ jobs:
     needs: ["lint", "build"]
     runs-on: "ubuntu-latest"
     env:
+      FOUNDRY_PROFILE: "via_ir"
       ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
       ARBITRUM_BLOCK: ${{ secrets.ARBITRUM_BLOCK }}
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -38,8 +38,6 @@ jobs:
   build:
     name: build
     runs-on: "ubuntu-latest"
-    env:
-      FOUNDRY_PROFILE: "via_ir"
     steps:
       - name: "Check out the repo"
         uses: "actions/checkout@v4"
@@ -61,7 +59,6 @@ jobs:
     needs: ["lint", "build"]
     runs-on: "ubuntu-latest"
     env:
-      FOUNDRY_PROFILE: "via_ir"
       ARBITRUM_RPC: ${{ secrets.ARBITRUM_RPC }}
       ARBITRUM_BLOCK: ${{ secrets.ARBITRUM_BLOCK }}
     steps:

--- a/contracts/.prettierignore
+++ b/contracts/.prettierignore
@@ -5,6 +5,7 @@ coverage
 node_modules
 out
 artifacts
+lib
 
 # files
 *.env

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -32,6 +32,7 @@
 
 [profile.ci]
   fuzz_runs = 1000
+  via_ir = true
 
 [profile.via_ir]
   auto_detect_solc = false

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -33,6 +33,32 @@
 [profile.ci]
   fuzz_runs = 1000
 
+[profile.via_ir]
+  auto_detect_solc = false
+  bytecode_hash = "none"
+  out = "artifacts/src"
+  test = "src/test"
+  libs = ["node_modules", "lib"]
+  cache = true
+  evm_version = 'cancun'
+  solc_version = '0.8.30'
+  optimizer = true
+  optimizer_runs = 200
+  via_ir = true
+  verbosity = 3
+  ignored_error_codes = []
+  fuzz_runs = 256
+  ffi = false
+  sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
+  initial_balance = '0xffffffffffffffffffffffff'
+  block_number = 0
+  gas_limit = 9223372036854775807
+  gas_price = 0
+  block_base_fee_per_gas = 0
+  block_coinbase = '0x0000000000000000000000000000000000000000'
+  block_timestamp = 0
+  block_difficulty = 0
+
 [fmt]
   bracket_spacing = true
   int_types = "long"

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -34,32 +34,6 @@
   fuzz_runs = 1000
   via_ir = true
 
-[profile.via_ir]
-  auto_detect_solc = false
-  bytecode_hash = "none"
-  out = "artifacts/src"
-  test = "src/test"
-  libs = ["node_modules", "lib"]
-  cache = true
-  evm_version = 'cancun'
-  solc_version = '0.8.30'
-  optimizer = true
-  optimizer_runs = 200
-  via_ir = true
-  verbosity = 3
-  ignored_error_codes = []
-  fuzz_runs = 256
-  ffi = false
-  sender = '0x00a329c0648769a73afac7f9381e08fb43dbea72'
-  initial_balance = '0xffffffffffffffffffffffff'
-  block_number = 0
-  gas_limit = 9223372036854775807
-  gas_price = 0
-  block_base_fee_per_gas = 0
-  block_coinbase = '0x0000000000000000000000000000000000000000'
-  block_timestamp = 0
-  block_difficulty = 0
-
 [fmt]
   bracket_spacing = true
   int_types = "long"

--- a/contracts/src/test/xYield/xYieldTest.t.sol
+++ b/contracts/src/test/xYield/xYieldTest.t.sol
@@ -62,6 +62,7 @@ contract xYieldTest is Test {
     address public prover = address(0x4);
 
     uint256 public constant INITIAL_DEPOSIT = 1000 * 10 ** 18;
+    uint256 public constant REBALANCE_ID = 1;
 
     address[] emptyAddresses;
     uint256[] emptyAmounts;
@@ -227,7 +228,7 @@ contract xYieldTest is Test {
             _createOrder(dstChainId, depositAmount, depositAmount, uint32(block.timestamp + 10_000_000), 0, false);
 
         vm.prank(guardian);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
 
         // Check that Open event was emitted
         Vm.Log[] memory logs = vm.getRecordedLogs();
@@ -259,7 +260,7 @@ contract xYieldTest is Test {
 
         vm.expectRevert(xYieldVault.ZeroAmount.selector);
         vm.prank(guardian);
-        vault.rebalance(dstChainId, 0, 0, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, 0, 0, 0);
     }
 
     function testRebalanceWithdrawOnInactiveChainRevert() public {
@@ -279,7 +280,7 @@ contract xYieldTest is Test {
 
         vm.expectRevert(xYieldVault.WithdrawOnInactiveChain.selector);
         vm.prank(guardian);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
     function testRebalanceInvalidChainRevert() public {
@@ -294,7 +295,7 @@ contract xYieldTest is Test {
 
         vm.expectRevert(xYieldVault.InvalidChain.selector);
         vm.prank(guardian);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
     function testRebalanceInvalidOrderDataDestinationDomainRevert() public {
@@ -313,7 +314,7 @@ contract xYieldTest is Test {
 
         vm.expectRevert(xYieldVault.InvalidOrderData.selector);
         vm.prank(guardian);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
     function testRebalanceInvalidOrderDataAmountInRevert() public {
@@ -332,7 +333,7 @@ contract xYieldTest is Test {
 
         vm.expectRevert(xYieldVault.InvalidOrderData.selector);
         vm.prank(guardian);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
     function testRebalanceNotGuardianRevert() public {
@@ -343,7 +344,7 @@ contract xYieldTest is Test {
             _createOrder(dstChainId, depositAmount, depositAmount, uint32(block.timestamp + 10_000_000), 0, false);
 
         vm.expectRevert(xYieldVault.NotGuardian.selector);
-        vault.rebalance(dstChainId, depositAmount, depositAmount, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
     function testUndoRebalance() public {
@@ -362,7 +363,7 @@ contract xYieldTest is Test {
         // Record logs to capture the orderId from Open event
         vm.recordLogs();
         vm.prank(guardian);
-        vault.rebalance(dstChainId, usdcBalance, usdcBalance, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
         // Extract orderId from Open event
         Vm.Log[] memory logs = vm.getRecordedLogs();
@@ -415,7 +416,7 @@ contract xYieldTest is Test {
         // Record logs to capture the orderId from Open event
         vm.recordLogs();
         vm.prank(guardian);
-        vault.rebalance(dstChainId, usdcBalance, usdcBalance, 0);
+        vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
         // Extract orderId from Open event
         Vm.Log[] memory logs = vm.getRecordedLogs();

--- a/contracts/src/test/xYield/xYieldTest.t.sol
+++ b/contracts/src/test/xYield/xYieldTest.t.sol
@@ -12,7 +12,6 @@ import { V3SpokePoolInterface } from "@across-protocol/contracts/contracts/inter
 import { xYieldVault } from "../../xYield/xYieldVault.sol";
 import { MockYieldProtocol } from "./MockYieldProtocol.sol";
 import { T1XChainReader } from "../../libraries/xChain/T1XChainReader.sol";
-import { T1ERC7683 } from "../../7683/T1ERC7683.sol";
 import {
     IOriginSettler,
     ResolvedCrossChainOrder,
@@ -20,7 +19,6 @@ import {
     FillInstruction,
     OnchainCrossChainOrder
 } from "../../interfaces/IERC7683.sol";
-import { IT1ERC7683 } from "../../interfaces/IT1ERC7683.sol";
 import { OrderData, OrderEncoder } from "../../libraries/7683/OrderEncoder.sol";
 import { TypeCasts } from "@hyperlane-xyz/libs/TypeCasts.sol";
 
@@ -93,12 +91,7 @@ contract xYieldTest is Test {
         usdc = new MockUSDC();
         yieldProtocol = new Mock4626(IERC20(address(usdc)), "Euler USDC", "eUSDC", true);
         reader = new T1XChainReader(prover);
-        // settler = new T1ERC7683(address(0), address(reader), uint32(block.chainid));
-        // settler = new T1ERC7683(address(0), address(reader), uint32(block.chainid));
         bridge = new MockSpokePool();
-
-        // Initialize the T1ERC7683 contract
-        // settler.initialize(address(0x1234), address(0x5678));
 
         vault = new xYieldVault(
             IERC20(address(usdc)), guardian, "xYield USDC", "xyUSDC", address(yieldProtocol), address(bridge)
@@ -254,20 +247,8 @@ contract xYieldTest is Test {
         vm.prank(guardian);
         vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
 
-        // Check that Open event was emitted
-        // Vm.Log[] memory logs = vm.getRecordedLogs();
-        // bool openEventFound = false;
-        // for (uint256 i = 0; i < logs.length; i++) {
-        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-        //         openEventFound = true;
-        //         break;
-        //     }
-        // }
-        // assertTrue(openEventFound, "Open event should have been emitted");
-
         assertFalse(vault.isActiveChain());
         assertEq(vault.virtualTotalAssets(), 0);
-        // assertEq(usdc.balanceOf(address(settler)), depositAmount, "settler should have the rebalanced amount");
     }
 
     function testRebalanceZeroAmountRevert() public {
@@ -351,22 +332,11 @@ contract xYieldTest is Test {
         vm.prank(guardian);
         vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
-        // Extract orderId from Open event
-        // Vm.Log[] memory logs = vm.getRecordedLogs();
-        // bytes32 orderId;
-        // for (uint256 i = 0; i < logs.length; i++) {
-        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-        //         orderId = logs[i].topics[1]; // orderId is the first indexed parameter
-        //         break;
-        //     }
-        // }
-
         // Warp time to make intent deadline pass
         vm.warp(block.timestamp + 1_000_000);
 
         bytes32 expectedRequestId = keccak256("mock_request_id");
         vm.mockCall(address(reader), abi.encodeWithSelector(reader.requestRead.selector), abi.encode(expectedRequestId));
-        // settler.verifyRefund(orderId);
 
         // Mock the cross-chain read to return empty result (order not filled)
         vm.mockCall(
@@ -382,7 +352,6 @@ contract xYieldTest is Test {
 
         assertTrue(vault.isActiveChain());
         assertEq(vault.virtualTotalAssets(), usdcBalance);
-        // assertEq(uint8(settler.orderStatus(orderId)), uint8(5), "Order status should be REFUNDED");
         assertEq(usdc.balanceOf(address(yieldProtocol)), usdcBalance, "yieldProtocol should get the amount returned");
     }
 
@@ -404,22 +373,11 @@ contract xYieldTest is Test {
         vm.prank(guardian);
         vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
-        // Extract orderId from Open event
-        // Vm.Log[] memory logs = vm.getRecordedLogs();
-        // bytes32 orderId;
-        // for (uint256 i = 0; i < logs.length; i++) {
-        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-        //         orderId = logs[i].topics[1]; // orderId is the first indexed parameter
-        //         break;
-        //     }
-        // }
-
         // Warp time to make intent deadline pass
         vm.warp(block.timestamp + 1_000_000);
 
         bytes32 expectedRequestId = keccak256("mock_request_id");
         vm.mockCall(address(reader), abi.encodeWithSelector(reader.requestRead.selector), abi.encode(expectedRequestId));
-        // settler.verifyRefund(orderId);
 
         // Mock the cross-chain read to return empty result (order not filled)
         vm.mockCall(

--- a/contracts/src/test/xYield/xYieldTest.t.sol
+++ b/contracts/src/test/xYield/xYieldTest.t.sol
@@ -62,7 +62,10 @@ contract MockSpokePool {
         uint32,
         uint32,
         bytes calldata
-    ) external payable {}
+    )
+        external
+        payable
+    { }
 
     function counterpart() external pure returns (address) {
         return address(0x1234);
@@ -406,7 +409,7 @@ contract xYieldTest is Test {
     {
         OrderData memory orderData;
         {
-            (address siblingVault, ) = vault.siblingVaults(dstChainId);
+            (address siblingVault,) = vault.siblingVaults(dstChainId);
             orderData = OrderData({
                 sender: TypeCasts.addressToBytes32(address(vault)),
                 recipient: TypeCasts.addressToBytes32(siblingVault),

--- a/contracts/src/test/xYield/xYieldTest.t.sol
+++ b/contracts/src/test/xYield/xYieldTest.t.sol
@@ -7,6 +7,7 @@ import { Vm } from "forge-std/Vm.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import { V3SpokePoolInterface } from "@across-protocol/contracts/contracts/interfaces/V3SpokePoolInterface.sol";
 
 import { xYieldVault } from "../../xYield/xYieldVault.sol";
 import { MockYieldProtocol } from "./MockYieldProtocol.sol";
@@ -49,12 +50,33 @@ contract Mock4626 is ERC4626 {
     }
 }
 
+contract MockSpokePool {
+    function depositV3(
+        address,
+        address,
+        address,
+        address,
+        uint256,
+        uint256,
+        uint256,
+        address,
+        uint32,
+        uint32,
+        uint32,
+        bytes calldata
+    ) external payable {}
+
+    function counterpart() external pure returns (address) {
+        return address(0x1234);
+    }
+}
+
 contract xYieldTest is Test {
     xYieldVault public vault;
     Mock4626 public yieldProtocol; // mocking a vault
     MockUSDC public usdc;
     T1XChainReader public reader;
-    T1ERC7683 public settler;
+    MockSpokePool public bridge;
 
     address public guardian = address(0x1);
     address public user1 = address(0x2);
@@ -71,13 +93,15 @@ contract xYieldTest is Test {
         usdc = new MockUSDC();
         yieldProtocol = new Mock4626(IERC20(address(usdc)), "Euler USDC", "eUSDC", true);
         reader = new T1XChainReader(prover);
-        settler = new T1ERC7683(address(0), address(reader), uint32(block.chainid));
+        // settler = new T1ERC7683(address(0), address(reader), uint32(block.chainid));
+        // settler = new T1ERC7683(address(0), address(reader), uint32(block.chainid));
+        bridge = new MockSpokePool();
 
         // Initialize the T1ERC7683 contract
-        settler.initialize(address(0x1234), address(0x5678));
+        // settler.initialize(address(0x1234), address(0x5678));
 
         vault = new xYieldVault(
-            IERC20(address(usdc)), guardian, "xYield USDC", "xyUSDC", address(yieldProtocol), address(settler)
+            IERC20(address(usdc)), guardian, "xYield USDC", "xyUSDC", address(yieldProtocol), address(bridge)
         );
 
         vm.prank(guardian);
@@ -219,7 +243,7 @@ contract xYieldTest is Test {
         vault.deposit(depositAmount, user1);
 
         vm.expectEmit(true, true, true, true);
-        emit xYieldVault.Rebalanced(dstChainId, depositAmount);
+        emit xYieldVault.RebalanceInitiated(REBALANCE_ID, dstChainId, depositAmount);
 
         // Record logs to check if Open event was emitted
         vm.recordLogs();
@@ -231,19 +255,19 @@ contract xYieldTest is Test {
         vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
 
         // Check that Open event was emitted
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bool openEventFound = false;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-                openEventFound = true;
-                break;
-            }
-        }
-        assertTrue(openEventFound, "Open event should have been emitted");
+        // Vm.Log[] memory logs = vm.getRecordedLogs();
+        // bool openEventFound = false;
+        // for (uint256 i = 0; i < logs.length; i++) {
+        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
+        //         openEventFound = true;
+        //         break;
+        //     }
+        // }
+        // assertTrue(openEventFound, "Open event should have been emitted");
 
         assertFalse(vault.isActiveChain());
         assertEq(vault.virtualTotalAssets(), 0);
-        assertEq(usdc.balanceOf(address(settler)), depositAmount, "settler should have the rebalanced amount");
+        // assertEq(usdc.balanceOf(address(settler)), depositAmount, "settler should have the rebalanced amount");
     }
 
     function testRebalanceZeroAmountRevert() public {
@@ -298,44 +322,6 @@ contract xYieldTest is Test {
         vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
     }
 
-    function testRebalanceInvalidOrderDataDestinationDomainRevert() public {
-        uint32 dstChainId = 1;
-        uint32 wrongChainId = 2;
-        uint256 depositAmount = 100 * 10 ** 18;
-
-        vault.setSiblingVault(dstChainId, address(12), address(usdc));
-
-        vm.prank(user1);
-        vault.deposit(depositAmount, user1);
-
-        // Create order with wrong destination domain
-        OnchainCrossChainOrder memory order =
-            _createOrder(wrongChainId, depositAmount, depositAmount, uint32(block.timestamp + 10_000_000), 0, false);
-
-        vm.expectRevert(xYieldVault.InvalidOrderData.selector);
-        vm.prank(guardian);
-        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
-    }
-
-    function testRebalanceInvalidOrderDataAmountInRevert() public {
-        uint32 dstChainId = 1;
-        uint256 depositAmount = 100 * 10 ** 18;
-        uint256 wrongAmount = 50 * 10 ** 18;
-
-        vault.setSiblingVault(dstChainId, address(12), address(usdc));
-
-        vm.prank(user1);
-        vault.deposit(depositAmount, user1);
-
-        // Create order with wrong amount
-        OnchainCrossChainOrder memory order =
-            _createOrder(dstChainId, wrongAmount, wrongAmount, uint32(block.timestamp + 10_000_000), 0, false);
-
-        vm.expectRevert(xYieldVault.InvalidOrderData.selector);
-        vm.prank(guardian);
-        vault.rebalance(REBALANCE_ID, dstChainId, depositAmount, depositAmount, 0);
-    }
-
     function testRebalanceNotGuardianRevert() public {
         uint32 dstChainId = 1;
         uint256 depositAmount = 100 * 10 ** 18;
@@ -366,21 +352,21 @@ contract xYieldTest is Test {
         vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
         // Extract orderId from Open event
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes32 orderId;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-                orderId = logs[i].topics[1]; // orderId is the first indexed parameter
-                break;
-            }
-        }
+        // Vm.Log[] memory logs = vm.getRecordedLogs();
+        // bytes32 orderId;
+        // for (uint256 i = 0; i < logs.length; i++) {
+        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
+        //         orderId = logs[i].topics[1]; // orderId is the first indexed parameter
+        //         break;
+        //     }
+        // }
 
         // Warp time to make intent deadline pass
         vm.warp(block.timestamp + 1_000_000);
 
         bytes32 expectedRequestId = keccak256("mock_request_id");
         vm.mockCall(address(reader), abi.encodeWithSelector(reader.requestRead.selector), abi.encode(expectedRequestId));
-        settler.verifyRefund(orderId);
+        // settler.verifyRefund(orderId);
 
         // Mock the cross-chain read to return empty result (order not filled)
         vm.mockCall(
@@ -396,7 +382,7 @@ contract xYieldTest is Test {
 
         assertTrue(vault.isActiveChain());
         assertEq(vault.virtualTotalAssets(), usdcBalance);
-        assertEq(uint8(settler.orderStatus(orderId)), uint8(5), "Order status should be REFUNDED");
+        // assertEq(uint8(settler.orderStatus(orderId)), uint8(5), "Order status should be REFUNDED");
         assertEq(usdc.balanceOf(address(yieldProtocol)), usdcBalance, "yieldProtocol should get the amount returned");
     }
 
@@ -419,21 +405,21 @@ contract xYieldTest is Test {
         vault.rebalance(REBALANCE_ID, dstChainId, usdcBalance, usdcBalance, 0);
 
         // Extract orderId from Open event
-        Vm.Log[] memory logs = vm.getRecordedLogs();
-        bytes32 orderId;
-        for (uint256 i = 0; i < logs.length; i++) {
-            if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
-                orderId = logs[i].topics[1]; // orderId is the first indexed parameter
-                break;
-            }
-        }
+        // Vm.Log[] memory logs = vm.getRecordedLogs();
+        // bytes32 orderId;
+        // for (uint256 i = 0; i < logs.length; i++) {
+        //     if (logs[i].emitter == address(settler) && logs[i].topics[0] == IOriginSettler.Open.selector) {
+        //         orderId = logs[i].topics[1]; // orderId is the first indexed parameter
+        //         break;
+        //     }
+        // }
 
         // Warp time to make intent deadline pass
         vm.warp(block.timestamp + 1_000_000);
 
         bytes32 expectedRequestId = keccak256("mock_request_id");
         vm.mockCall(address(reader), abi.encodeWithSelector(reader.requestRead.selector), abi.encode(expectedRequestId));
-        settler.verifyRefund(orderId);
+        // settler.verifyRefund(orderId);
 
         // Mock the cross-chain read to return empty result (order not filled)
         vm.mockCall(
@@ -460,23 +446,25 @@ contract xYieldTest is Test {
         view
         returns (OnchainCrossChainOrder memory)
     {
-        (address siblingVault, ) = vault.siblingVaults(dstChainId);
-
-        OrderData memory orderData = OrderData({
-            sender: TypeCasts.addressToBytes32(address(vault)),
-            recipient: TypeCasts.addressToBytes32(siblingVault),
-            inputToken: TypeCasts.addressToBytes32(address(usdc)),
-            outputToken: TypeCasts.addressToBytes32(address(usdc)),
-            amountIn: amount,
-            minAmountOut: minAmountOut,
-            senderNonce: nonce,
-            originDomain: uint32(block.chainid),
-            destinationDomain: dstChainId,
-            destinationSettler: TypeCasts.addressToBytes32(T1ERC7683(address(settler)).counterpart()),
-            fillDeadline: fillDeadline,
-            closedAuction: closedAuction,
-            data: new bytes(0)
-        });
+        OrderData memory orderData;
+        {
+            (address siblingVault, ) = vault.siblingVaults(dstChainId);
+            orderData = OrderData({
+                sender: TypeCasts.addressToBytes32(address(vault)),
+                recipient: TypeCasts.addressToBytes32(siblingVault),
+                inputToken: TypeCasts.addressToBytes32(address(usdc)),
+                outputToken: TypeCasts.addressToBytes32(address(usdc)),
+                amountIn: amount,
+                minAmountOut: minAmountOut,
+                senderNonce: nonce,
+                originDomain: uint32(block.chainid),
+                destinationDomain: dstChainId,
+                destinationSettler: TypeCasts.addressToBytes32(MockSpokePool(address(bridge)).counterpart()),
+                fillDeadline: fillDeadline,
+                closedAuction: closedAuction,
+                data: new bytes(0)
+            });
+        }
 
         return OnchainCrossChainOrder({
             fillDeadline: fillDeadline,

--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -61,7 +61,8 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     event TotalSupplyUpdated(uint256 newVirtualTotalSupply);
     event ChainStatusChanged(bool isActive);
     event SiblingVaultSet(uint64 chainId, address vault);
-    event Rebalanced(uint256 targetChain, uint256 amount);
+    event RebalanceInitiated(uint256 indexed id, uint256 targetChain, uint256 amount);
+    event Rebalanced(uint256 indexed id, uint256 amount);
     event RebalanceUndone(uint256 targetChain, uint256 amount);
 
     modifier onlyGuardian() {
@@ -305,6 +306,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
     }
 
     function rebalance(
+        uint256 _id,
         uint32 _targetChain,
         uint256 _amountIn,
         uint256 _amountOut,
@@ -324,6 +326,8 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         yieldProtocol.withdraw(_amountIn, address(this), address(this));
         updateVirtualTotalAssets();
 
+        bytes memory message = abi.encode(_id);
+
         acrossSpokePool.depositV3(
             guardian,
             siblingVault.vault,
@@ -336,10 +340,10 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
             _acrossApiQuoteTimestamp,
             uint32(block.timestamp + 2 minutes),
             0,
-            ""
+            message
         );
 
-        emit Rebalanced(_targetChain, _amountIn);
+        emit RebalanceInitiated(_id, _targetChain, _amountIn);
     }
 
     /// @notice Wrapper around the settler contract `refund` function to be called after a PoR
@@ -368,5 +372,15 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
 
     function unpause() external onlyOwner {
         _unpause();
+    }
+
+    function handleV3AcrossMessage(
+        address tokenSent,
+        uint256 amount,
+        address relayer,
+        bytes memory message
+    ) external {
+        uint256 id = abi.decode(message, (uint256));
+        emit Rebalanced(id, amount);
     }
 }

--- a/contracts/src/xYield/xYieldVault.sol
+++ b/contracts/src/xYield/xYieldVault.sol
@@ -374,12 +374,7 @@ contract xYieldVault is ERC4626, Ownable2Step, ReentrancyGuard, Pausable {
         _unpause();
     }
 
-    function handleV3AcrossMessage(
-        address tokenSent,
-        uint256 amount,
-        address relayer,
-        bytes memory message
-    ) external {
+    function handleV3AcrossMessage(address tokenSent, uint256 amount, address relayer, bytes memory message) external {
         uint256 id = abi.decode(message, (uint256));
         emit Rebalanced(id, amount);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- add message param containing id of rebalance decode message in handleV3AcrossMessage hook to emit ID from `Rebalanced` event
- compile with via_ir profile to avoid stack too deep error && use via_ir profile in github actions build and
test
- turn on `via_ir` for CI profile
- add step to install libusb in `action.yaml`
<!--- Describe your changes in detail -->

## Motivation and Context
For main features: We need to emit an event that references a rebalance request with a given ID. This is enabled by the Across v3 hook `handleV3AcrossMessage` which is called when the intent is filled. Offchain component will index this event and mark the rebalance as complete in the DB.

For adding `libusb`, check [this thread](https://t1protocol.slack.com/archives/C08QD9KU2SV/p1757087824381199)
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
All existing tests passing. Once this contract version is deployed we can run an E2E manual test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] New feature (non-breaking change which adds functionality)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.