### PR TITLE
chore: add pnpm workspace with minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+# Do not pull packages newer than one day
+## this ensures packages have 24 hours for a hack to be noticed and fixed before we would decide to pull it
+minimumReleaseAge: 1440


### PR DESCRIPTION
## Description

Sets the minimum package age to one day in pnpm

## Motivation and Context

helps to prevent undiscovered malicious code in packages from affecting us by giving a 24 hours window before we are willing to install them

## How Has This Been Tested?

manually

## Types of changes (remove all unchecked types)

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.