### PR TITLE
Feature: proxy admin owner on deploy

### DIFF
--- a/contracts/script/deploy/DeployArbT1ProxyAdmin.s.sol
+++ b/contracts/script/deploy/DeployArbT1ProxyAdmin.s.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.25;
 import { Script } from "forge-std/Script.sol";
 import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
 
@@ -18,10 +19,21 @@ contract DeployArbT1ProxyAdmin is Script, DeploymentUtils {
         startBroadcastWithDeployerKeyIfItExists();
 
         deployProxyAdmin();
+        transferProxyAdminOwnershipIfNeeded();
+
+        vm.stopBroadcast();
     }
 
     function deployProxyAdmin() internal {
         proxyAdmin = new ProxyAdmin();
         logAddress("ARB_T1_PROXY_ADMIN_ADDR", address(proxyAdmin));
+    }
+
+    function transferProxyAdminOwnershipIfNeeded() internal {
+        address proxyAdminOwner = vm.envOr("ARB_T1_PROXY_ADMIN_OWNER_ADDR", address(0));
+        if (proxyAdminOwner != address(0)) {
+            Ownable(address(proxyAdmin)).transferOwnership(proxyAdminOwner);
+            logAddress("ARB_T1_PROXY_ADMIN_OWNER_ADDR", proxyAdminOwner);
+        }
     }
 }

--- a/contracts/script/deploy/DeployBaseT1ProxyAdmin.s.sol
+++ b/contracts/script/deploy/DeployBaseT1ProxyAdmin.s.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.8.25;
 import { Script } from "forge-std/Script.sol";
 import { ProxyAdmin } from "@openzeppelin/contracts/proxy/transparent/ProxyAdmin.sol";
 import { TransparentUpgradeableProxy } from "@openzeppelin/contracts/proxy/transparent/TransparentUpgradeableProxy.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
 
 import { DeploymentUtils } from "../lib/DeploymentUtils.sol";
 
@@ -17,6 +18,7 @@ contract DeployBaseT1ProxyAdmin is Script, DeploymentUtils {
         startBroadcastWithDeployerKeyIfItExists();
 
         deployProxyAdmin();
+        transferProxyAdminOwnershipIfNeeded();
 
         vm.stopBroadcast();
     }
@@ -24,5 +26,13 @@ contract DeployBaseT1ProxyAdmin is Script, DeploymentUtils {
     function deployProxyAdmin() internal {
         proxyAdmin = new ProxyAdmin();
         logAddress("BASE_T1_PROXY_ADMIN_ADDR", address(proxyAdmin));
+    }
+
+    function transferProxyAdminOwnershipIfNeeded() internal {
+        address proxyAdminOwner = vm.envOr("BASE_T1_PROXY_ADMIN_OWNER_ADDR", address(0));
+        if (proxyAdminOwner != address(0)) {
+            Ownable(address(proxyAdmin)).transferOwnership(proxyAdminOwner);
+            logAddress("BASE_T1_PROXY_ADMIN_OWNER_ADDR", proxyAdminOwner);
+        }
     }
 }


### PR DESCRIPTION
## Description

Creates and easy way to set the proxy admin owner when deploying

## Motivation and Context

Saves the deployer from having to call transfer manually

## How Has This Been Tested?

manually

## Types of changes (remove all unchecked types)

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.