### PR TITLE
Feat/sealed bid auction/ws outage resistance

### DIFF
--- a/tee-apps/sealed-bid-auction/bun.lock
+++ b/tee-apps/sealed-bid-auction/bun.lock
@@ -1,16 +1,17 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "sealed-bid-auction",
       "dependencies": {
         "@jest/globals": "^30.0.5",
-        "bun": "^1.2.19",
+        "bun": "^1.3.5",
         "dotenv": "^17.2.1",
         "immutable": "^5.1.3",
         "jest": "^30.0.5",
         "ts-jest": "^29.4.0",
-        "viem": "^2.33.1",
+        "viem": "^2.43.3",
         "winston": "^3.17.0",
       },
       "devDependencies": {
@@ -160,31 +161,31 @@
 
     "@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 
-    "@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
+    "@noble/curves": ["@noble/curves@1.9.1", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.2.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-pJBuez9gwR03Wjtk4hSSBA6QgNdhvPLbrxU4DDzVY8Ee+Q67xNkU0CMK6rFdQF8Qetj2R+Vf8AJDlwAc1QdG1w=="],
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8GvNtMo0NINM7Emk9cNAviCG3teEgr3BUX9be0+GD029zIagx2Sf54jMui1Eu1IpFm7nWHODuLEefGOQNaJ0gQ=="],
 
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.2.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-dsgmgDOG++JsQ3wXEyTiUzhT/4wqcnAxfCQOPho6LgosVUPs6etn01uA1yCySjSk8DrugQIivXB2TaqoOrhKJg=="],
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-r33eHQOHAwkuiBJIwmkXIyqONQOQMnd1GMTpDzaxx9vf9+svby80LZO9Hcm1ns6KT/TBRFyODC/0loA7FAaffg=="],
 
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.2.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-fOqbLeP3MoSbeosykTp1+BYSKDJxdjWKyxbPqHTJK2Mnt78+LPTE2yQbCzUL5LBLSRVkIxbTyIcEZxVg3eJmYg=="],
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-p5q3rJk48qhLuLBOFehVc+kqCE03YrswTc6NCxbwsxiwfySXwcAvpF2KWKF/ZZObvvR8hCCvqe1F81b2p5r2dg=="],
 
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.2.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-G4WYbvpfrR5dLBZQoNmYzt8DBguMpPeCz6feU3Qv9E6NmA3xiqyItyDAVgDJrllPk6hvbMi9dYNxXn0NVTjMfw=="],
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-zkcHPI23QxJ1TdqafhgkXt1NOEN8o5C460sVeNnrhfJ43LwZgtfcvcQE39x/pBedu67fatY8CU0iY00nOh46ZQ=="],
 
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.2.19", "", { "os": "linux", "cpu": "none" }, "sha512-awB1ZEh7AbxXGemT/d33F6F4bwClWSFjhcatrweG5o5gh16c4pBKTldg/TUY9EEFrQJVyYQklgl/D919GDLTFA=="],
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-HKBeUlJdNduRkzJKZ5DXM+pPqntfC50/Hu2X65jVX0Y7hu/6IC8RaUTqpr8FtCZqqmc9wDK0OTL+Mbi9UQIKYQ=="],
 
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.2.19", "", { "os": "linux", "cpu": "x64" }, "sha512-vGhkEtcaPQjizoVAo+1hsVTixarOWxVgwbYZHgoi/pGGIdWWBGNlWnIUQirOv8JVtCMnzkYqrPMHR3EqSvQoFg=="],
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-n7zhKTSDZS0yOYg5Rq8easZu5Y/o47sv0c7yGr2ciFdcie9uYV55fZ7QMqhWMGK33ezCSikh5EDkUMCIvfWpjA=="],
 
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.2.19", "", { "os": "linux", "cpu": "x64" }, "sha512-gMp1J9fZ1eOrCM0jQblCWRMiU9t3a+wyyHtb0DdHVZpgSdGJ5UpWATfTYFUbmckgVfCJ6Qo8YSMcmtxRtPYgww=="],
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FeCQyBU62DMuB0nn01vPnf3McXrKOsrK9p7sHaBFYycw0mmoU8kCq/WkBkGMnLuvQljJSyen8QBTx+fXdNupWg=="],
 
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.2.19", "", { "os": "linux", "cpu": "x64" }, "sha512-nUBP55pR8hpAZ9omKxkX1SmyEPcTL/ZMgnirC3BdFAec99uqijq8XEWWfSDAmpI8D428vjIhbafArmbutRR1VQ=="],
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-XkCCHkByYn8BIDvoxnny898znju4xnW2kvFE8FT5+0Y62cWdcBGMZ9RdsEUTeRz16k8hHtJpaSfLcEmNTFIwRQ=="],
 
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.2.19", "", { "os": "linux", "cpu": "x64" }, "sha512-9NkUMndXwSyDiDOwCtYoxdXIqg+f30dVm0FwZOUJp8SSuhx8Vaadc5gzzC+A8cGie/IwVchWzJw+mWLStAM8HQ=="],
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.5", "", { "os": "linux", "cpu": "x64" }, "sha512-TJiYC7KCr0XxFTsxgwQOeE7dncrEL/RSyL0EzSL3xRkrxJMWBCvCSjQn7LV1i6T7hFst0+3KoN3VWvD5BinqHA=="],
 
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.2.19", "", { "os": "win32", "cpu": "x64" }, "sha512-5OIPUl8fKT/tpxX6pOJUfoAR32k9YdmXbte0zwahIVhyjCyFh0HKQHbfSeJZYV2AzVWbnELszDLRRLnzVbzYSQ=="],
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-T3xkODItb/0ftQPFsZDc7EAX2D6A4TEazQ2YZyofZToO8Q7y8YT8ooWdhd0BQiTCd66uEvgE1DCZetynwg2IoA=="],
 
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.2.19", "", { "os": "win32", "cpu": "x64" }, "sha512-OiD1xoVQuj8JHbrDqCQE3sU5r8VIaB9cCDym7BTnnMQLYzZxYEWWvBub8fc/yK7ctuoAS6V+p74Qda6RhDRHpg=="],
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.5", "", { "os": "win32", "cpu": "x64" }, "sha512-rtVQB9/1XK8FWJgFtsOthbPifRMYypgJwxu+pK3NHx8WvFKmq7HcPDqNr8xLzGULjQEO7eAo2aOZfONOwYz+5g=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
@@ -272,7 +273,7 @@
 
     "@unrs/resolver-binding-win32-x64-msvc": ["@unrs/resolver-binding-win32-x64-msvc@1.11.1", "", { "os": "win32", "cpu": "x64" }, "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g=="],
 
-    "abitype": ["abitype@1.0.8", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3 >=3.22.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-ZeiI6h3GnW06uYDLx0etQtX/p8E24UaHHBj57RSjK7YBFe7iuVn07EDpOeP451D06sF27VOz9JJPlIKJmXgkEg=="],
+    "abitype": ["abitype@1.2.3", "", { "peerDependencies": { "typescript": ">=5.0.4", "zod": "^3.22.0 || ^4.0.0" }, "optionalPeers": ["typescript", "zod"] }, "sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg=="],
 
     "ansi-escapes": ["ansi-escapes@4.3.2", "", { "dependencies": { "type-fest": "^0.21.3" } }, "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ=="],
 
@@ -310,7 +311,7 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
-    "bun": ["bun@1.2.19", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.2.19", "@oven/bun-darwin-x64": "1.2.19", "@oven/bun-darwin-x64-baseline": "1.2.19", "@oven/bun-linux-aarch64": "1.2.19", "@oven/bun-linux-aarch64-musl": "1.2.19", "@oven/bun-linux-x64": "1.2.19", "@oven/bun-linux-x64-baseline": "1.2.19", "@oven/bun-linux-x64-musl": "1.2.19", "@oven/bun-linux-x64-musl-baseline": "1.2.19", "@oven/bun-windows-x64": "1.2.19", "@oven/bun-windows-x64-baseline": "1.2.19" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-P70KUfH9cvgcl8Hjvamr98NinEatV23yX6qaY7z1+3rBPdds0oVX0u6FfrYnWc8F3ayFQ4do6/6xBLWY4itJkQ=="],
+    "bun": ["bun@1.3.5", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "1.3.5", "@oven/bun-darwin-x64": "1.3.5", "@oven/bun-darwin-x64-baseline": "1.3.5", "@oven/bun-linux-aarch64": "1.3.5", "@oven/bun-linux-aarch64-musl": "1.3.5", "@oven/bun-linux-x64": "1.3.5", "@oven/bun-linux-x64-baseline": "1.3.5", "@oven/bun-linux-x64-musl": "1.3.5", "@oven/bun-linux-x64-musl-baseline": "1.3.5", "@oven/bun-windows-x64": "1.3.5", "@oven/bun-windows-x64-baseline": "1.3.5" }, "os": [ "linux", "win32", "darwin", ], "cpu": [ "x64", "arm64", ], "bin": { "bun": "bin/bun.exe", "bunx": "bin/bunx.exe" } }, "sha512-c1YHIGUfgvYPJmLug5QiLzNWlX2Dg7X/67JWu1Va+AmMXNXzC/KQn2lgQ7rD+n1u1UqDpJMowVGGxTNpbPydNw=="],
 
     "bun-types": ["bun-types@1.2.19", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-uAOTaZSPuYsWIXRpj7o56Let0g/wjihKCkeRqUBhlLVM/Bt+Fj9xTo+LhC1OV1XDaGkz4hNC80et5xgy+9KTHQ=="],
 
@@ -576,7 +577,7 @@
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
 
-    "ox": ["ox@0.8.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "^1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.0.8", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-e+z5epnzV+Zuz91YYujecW8cF01mzmrUtWotJ0oEPym/G82uccs7q0WDHTYL3eiONbTUEvcZrptAKLgTBD3u2A=="],
+    "ox": ["ox@0.11.1", "", { "dependencies": { "@adraffy/ens-normalize": "^1.11.0", "@noble/ciphers": "^1.3.0", "@noble/curves": "1.9.1", "@noble/hashes": "^1.8.0", "@scure/bip32": "^1.7.0", "@scure/bip39": "^1.6.0", "abitype": "^1.2.3", "eventemitter3": "5.0.1" }, "peerDependencies": { "typescript": ">=5.4.0" }, "optionalPeers": ["typescript"] }, "sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
@@ -696,7 +697,7 @@
 
     "v8-to-istanbul": ["v8-to-istanbul@9.3.0", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.12", "@types/istanbul-lib-coverage": "^2.0.1", "convert-source-map": "^2.0.0" } }, "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA=="],
 
-    "viem": ["viem@2.33.1", "", { "dependencies": { "@noble/curves": "1.9.2", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.0.8", "isows": "1.0.7", "ox": "0.8.1", "ws": "8.18.2" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-++Dkj8HvSOLPMKEs+ZBNNcWbBRlUHcXNWktjIU22hgr6YmbUldV1sPTGLZa6BYRm06WViMjXj6HIsHt8rD+ZKQ=="],
+    "viem": ["viem@2.43.4", "", { "dependencies": { "@noble/curves": "1.9.1", "@noble/hashes": "1.8.0", "@scure/bip32": "1.7.0", "@scure/bip39": "1.6.0", "abitype": "1.2.3", "isows": "1.0.7", "ox": "0.11.1", "ws": "8.18.3" }, "peerDependencies": { "typescript": ">=5.0.4" }, "optionalPeers": ["typescript"] }, "sha512-PSoML7uG5es/SA1v2988grfcHdMDIogqC0LftdX74q8ZUHj3E7uiAXypNQiUxRZBuyoD5LO1nGEgTU9AGRvuHA=="],
 
     "walker": ["walker@1.0.8", "", { "dependencies": { "makeerror": "1.0.12" } }, "sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ=="],
 
@@ -714,7 +715,7 @@
 
     "write-file-atomic": ["write-file-atomic@5.0.1", "", { "dependencies": { "imurmurhash": "^0.1.4", "signal-exit": "^4.0.1" } }, "sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw=="],
 
-    "ws": ["ws@8.18.2", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ=="],
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
@@ -737,6 +738,8 @@
     "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
 
     "@istanbuljs/load-nyc-config/camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
+    "@scure/bip32/@noble/curves": ["@noble/curves@1.9.2", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g=="],
 
     "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 

--- a/tee-apps/sealed-bid-auction/package.json
+++ b/tee-apps/sealed-bid-auction/package.json
@@ -15,12 +15,12 @@
   },
   "dependencies": {
     "@jest/globals": "^30.0.5",
-    "bun": "^1.2.19",
+    "bun": "^1.3.5",
     "dotenv": "^17.2.1",
     "immutable": "^5.1.3",
     "jest": "^30.0.5",
     "ts-jest": "^29.4.0",
-    "viem": "^2.33.1",
+    "viem": "^2.43.3",
     "winston": "^3.17.0"
   }
 }

--- a/tee-apps/sealed-bid-auction/src/api/AuctionApiServer.ts
+++ b/tee-apps/sealed-bid-auction/src/api/AuctionApiServer.ts
@@ -5,7 +5,6 @@ import {serialize, WinstonLogger} from "../utils/WinstonLogger.ts";
 import {SolverPriceBook} from "../core/SolverPriceBook.ts";
 import {AuctionService} from "../core/AuctionService.ts";
 import type {AuctionResult} from "./types.ts";
-import type {OrderData} from "../blockchain/types.ts";
 import type {PriceListItem} from "../core/types.ts";
 import {AuthController} from "./AuthController.ts";
 import {AuthService} from "../core/AuthService.ts";
@@ -120,11 +119,11 @@ export class AuctionApiServer {
                         ws.send(`Error when updating price: ${e.message || e}`);
                     }
                 },
-                close: (ws, _code, _reason) => {
+                close: (ws, code, reason) => {
                     const addr = ws.data.solverAddress;
                     const user = ws.data.username;
                     ws.unsubscribe('intent-auction');
-                    websocketLogger.info(`🔒 Solver disconnected: ${user} (${addr})`);
+                    websocketLogger.info(`🔒 Solver disconnected: ${user} (${addr}) . Code: ${code} Reason: ${reason || '<no reason>'}.`);
                     authService.logout(addr);
                 },
             },

--- a/tee-apps/sealed-bid-auction/src/blockchain/BlockchainClient.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/BlockchainClient.ts
@@ -12,9 +12,13 @@ export class BlockchainClient {
         this._publicClient = createPublicClient({
             chain: chain,
             transport: webSocket(wsUrl, {
-                reconnect: true,
-                keepAlive: true,
-                retryDelay: 1000,
+                reconnect: {
+                  attempts: Infinity,
+                  delay: 1000,
+                },
+                keepAlive: {
+                  interval: 15000,
+                },
             }),
         });
     }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -133,7 +133,7 @@ export class ViemIntentObserver {
 
         const orderData = decodedOrder as OrderData;
 
-        await this.runAuctionAndNotifySolver(
+        this.runAuctionAndNotifySolver(
           {
             sender: trim(orderData.sender),
             recipient: trim(orderData.recipient),
@@ -151,8 +151,7 @@ export class ViemIntentObserver {
           },
           order.args.orderId,
           openEvent
-        );
-        this.lastProcessedBlock = BigInt(rawLog.blockNumber);
+        ).then(() => this.lastProcessedBlock = BigInt(rawLog.blockNumber));
       }
     }
   }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -53,7 +53,7 @@ export class ViemIntentObserver {
       event: OPEN_INTENT_ABI_EVENT,
       onLogs: async (logs) => {
         if (this.websocketError && this.lastProcessedBlock) {
-          await this.fetchHistoricalLogs(this.lastProcessedBlock);
+          await this.fetchHistoricalLogs(this.lastProcessedBlock + 1);
           this.websocketError = false;
         }
         await this.processIntentLogs(logs);

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -2,7 +2,6 @@ import {
   decodeAbiParameters,
   parseEventLogs,
   trim,
-  type Log,
   type WatchEventOnLogsParameter,
 } from "viem";
 
@@ -30,7 +29,7 @@ export class ViemIntentObserver {
     private readonly destinationChainId: number,
     private readonly destinationChainT1Erc7683ContractAddress: `0x${string}`,
     private readonly auctionPollingInterval: number = 500,
-    private readonly fromBlock: bigint | null
+    private readonly initialFromBlock: bigint | null
   ) {
     this.logger = new WinstonLogger(
       `${ViemIntentObserver.name}[${this.sourceChainClient.publicClient.chain.name}]`
@@ -38,8 +37,8 @@ export class ViemIntentObserver {
   }
 
   public async start() {
-    if (this.fromBlock !== null) {
-      await this.fetchHistoricalLogs();
+    if (this.initialFromBlock !== null) {
+      await this.fetchHistoricalLogs(this.initialFromBlock);
     }
 
     this.startWatching();
@@ -58,15 +57,11 @@ export class ViemIntentObserver {
     );
   }
 
-  private async fetchHistoricalLogs() {
-    if (this.fromBlock === null) return;
-
+  private async fetchHistoricalLogs(fromBlock: bigint) {
     const currentBlock = await this.sourceChainClient.publicClient.getBlockNumber();
     this.logger.info(
-      `Fetching historical logs from block ${this.fromBlock} to ${currentBlock}`
+      `Fetching historical logs from block ${fromBlock} to ${currentBlock}`
     );
-
-    let fromBlock = this.fromBlock;
 
     while (fromBlock <= currentBlock) {
       const toBlock = fromBlock + HISTORICAL_BLOCK_CHUNK_SIZE - 1n > currentBlock

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -20,6 +20,9 @@ const HISTORICAL_BLOCK_CHUNK_SIZE = 100n;
 
 export class ViemIntentObserver {
   private logger: WinstonLogger;
+
+  private websocketError: boolean = false;
+  private lastProcessedBlock: bigint | null = null;
   
   constructor(
     private readonly sourceChainClient: BlockchainClient,
@@ -48,8 +51,17 @@ export class ViemIntentObserver {
     this.sourceChainClient.publicClient.watchEvent({
       address: this.sourceChainT1Erc7683ContractAddress,
       event: OPEN_INTENT_ABI_EVENT,
-      onLogs: (logs) => this.processIntentLogs(logs),
-      onError: (error) => this.logger.error(`Error from publicClient.watchEvent: ${error}`),
+      onLogs: async (logs) => {
+        if (this.websocketError && this.lastProcessedBlock) {
+          await this.fetchHistoricalLogs(this.lastProcessedBlock);
+          this.websocketError = false;
+        }
+        await this.processIntentLogs(logs);
+      },
+      onError: (error) => {
+        this.websocketError = true;
+        this.logger.error(`Error from publicClient.watchEvent: ${error}`);
+      },
     });
 
     this.logger.info(
@@ -98,7 +110,7 @@ export class ViemIntentObserver {
 
     for (let i = 0; i < parsedLogs.length; i++) {
       const order = parsedLogs[i];
-      const rawLog = logs[i];
+      const rawLog = logs[i]!;
 
       // Convert raw log to eth_getLogs hex format for tokka-filler
       const openEvent: OpenEventLog = {
@@ -140,6 +152,7 @@ export class ViemIntentObserver {
           order.args.orderId,
           openEvent
         );
+        this.lastProcessedBlock = BigInt(rawLog.blockNumber);
       }
     }
   }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -53,6 +53,7 @@ export class ViemIntentObserver {
       event: OPEN_INTENT_ABI_EVENT,
       onLogs: async (logs) => {
         if (this.websocketError && this.lastProcessedBlock) {
+          this.logger.info(`I recovered from websocket error! Fetching historical logs from block ${this.lastProcessedBlock + 1n}`);
           await this.fetchHistoricalLogs(this.lastProcessedBlock + 1n);
           this.websocketError = false;
         }

--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -53,7 +53,7 @@ export class ViemIntentObserver {
       event: OPEN_INTENT_ABI_EVENT,
       onLogs: async (logs) => {
         if (this.websocketError && this.lastProcessedBlock) {
-          await this.fetchHistoricalLogs(this.lastProcessedBlock + 1);
+          await this.fetchHistoricalLogs(this.lastProcessedBlock + 1n);
           this.websocketError = false;
         }
         await this.processIntentLogs(logs);

--- a/tee-apps/sealed-bid-auction/src/bot/samplePriceLists.ts
+++ b/tee-apps/sealed-bid-auction/src/bot/samplePriceLists.ts
@@ -34,8 +34,8 @@ export const ATTRACTIVE_ARBITRUM_PRICE: PriceListItem[] = [{
             }
         }
     ],
-    srcTokenAddresses: ["0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC"],
-    dstTokenAddresses: ["0xF6232a871BF3B33F5bc181f55d770F9FB062A457"],
+    srcTokenAddresses: ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
+    dstTokenAddresses: ["0xaf88d065e77c8cC2239327C5EDb3A432268e5831"],
     settlementReceiverAddress: "0xa3e5e908868E2D881E70c304C18636A2f43E933f"
 },
     {
@@ -72,8 +72,8 @@ export const ATTRACTIVE_ARBITRUM_PRICE: PriceListItem[] = [{
             }
             }
         ],
-        srcTokenAddresses: ["0xF6232a871BF3B33F5bc181f55d770F9FB062A457"],
-        dstTokenAddresses: ["0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC"],
+        srcTokenAddresses: ["0xaf88d065e77c8cC2239327C5EDb3A432268e5831"],
+        dstTokenAddresses: ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
         settlementReceiverAddress: "0xa3e5e908868E2D881E70c304C18636A2f43E933f"
     }];
 
@@ -111,8 +111,8 @@ export const ATTRACTIVE_BASE_PRICE: PriceListItem[] = [{
             }
         }
     ],
-    srcTokenAddresses: ["0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC"],
-    dstTokenAddresses: ["0xF6232a871BF3B33F5bc181f55d770F9FB062A457"],
+    srcTokenAddresses: ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
+    dstTokenAddresses: ["0xaf88d065e77c8cC2239327C5EDb3A432268e5831"],
     settlementReceiverAddress: "0xD99c1b45708a4E94c6230f6A77BD7fa729f5398B"
 },
     {
@@ -149,7 +149,7 @@ export const ATTRACTIVE_BASE_PRICE: PriceListItem[] = [{
             }
             }
         ],
-        srcTokenAddresses: ["0xF6232a871BF3B33F5bc181f55d770F9FB062A457"],
-        dstTokenAddresses: ["0x228eE6c1C297E2Eba0e95A71684B26f89385b4eC"],
+        srcTokenAddresses: ["0xaf88d065e77c8cC2239327C5EDb3A432268e5831"],
+        dstTokenAddresses: ["0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"],
         settlementReceiverAddress: "0xD99c1b45708a4E94c6230f6A77BD7fa729f5398B"
     }];


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Makes our `Sealed Bid Auction Server` resistant to WebSocket connection dropping due to external factors by:
- persistently reconnecting after connection drops
- processing missed blocks after WS reconnects 

Also, removes `await` on processing a single intent auction, so that next intents are processed in parallel. Without that, if no solver is found for an intent then processing other intents is blocked until we reach `fillDeadline` for that intents (which could be a long time) .

<!--- Describe your changes in detail -->

## Motivation and Context

Because we only tried to reconnect 5 times when WS connection dropped, which resulted in no longer listening to inbound intents. Also, we were missing intents every now and then if they happened when WS connection was down.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

tested on local, against mainnet contracts!

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.