### PR TITLE
feat: periodic recovery after WS failure

### DIFF
--- a/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
+++ b/tee-apps/sealed-bid-auction/src/blockchain/ViemIntentObserver.ts
@@ -21,7 +21,8 @@ const HISTORICAL_BLOCK_CHUNK_SIZE = 100n;
 export class ViemIntentObserver {
   private logger: WinstonLogger;
 
-  private websocketError: boolean = false;
+  private catchupTimer: Timer | null = null;
+  private catchupRunning = false;
   private lastProcessedBlock: bigint | null = null;
   
   constructor(
@@ -52,15 +53,16 @@ export class ViemIntentObserver {
       address: this.sourceChainT1Erc7683ContractAddress,
       event: OPEN_INTENT_ABI_EVENT,
       onLogs: async (logs) => {
-        if (this.websocketError && this.lastProcessedBlock) {
-          this.logger.info(`I recovered from websocket error! Fetching historical logs from block ${this.lastProcessedBlock + 1n}`);
-          await this.fetchHistoricalLogs(this.lastProcessedBlock + 1n);
-          this.websocketError = false;
-        }
         await this.processIntentLogs(logs);
       },
       onError: (error) => {
-        this.websocketError = true;
+        if (!this.catchupTimer) {
+          this.catchupTimer = setInterval(
+            () => this.tryRecoverWebsocket(),
+            5_000,
+          );
+        }
+
         this.logger.error(`Error from publicClient.watchEvent: ${error}`);
       },
     });
@@ -244,5 +246,31 @@ export class ViemIntentObserver {
     };
 
     return await this.sourceChainClient.signTypedData(domain, types, message);
+  }
+
+  private async tryRecoverWebsocket() {
+    if (this.catchupRunning) return;
+    this.catchupRunning = true;
+
+    try {
+      // This will throw while the endpoint is still unavailable.
+      await this.sourceChainClient.publicClient.getBlockNumber();
+
+      const nextBlock = this.lastProcessedBlock ? this.lastProcessedBlock + 1n : this.initialFromBlock ?? 0n;
+
+      this.logger.info(
+        `WS recovered (RPC reachable). Catching up from block ${nextBlock.toString()}`,
+      );
+      await this.fetchHistoricalLogs(nextBlock);
+
+      if (this.catchupTimer) {
+        clearInterval(this.catchupTimer);
+        this.catchupTimer = null;
+      }
+    } catch (e) {
+      this.logger.debug(`Catchup poll failed (WS still down): ${e}`);
+    } finally {
+      this.catchupRunning = false;
+    }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After WebSocket hangs up, tries to reconnect and process missed blocks every 5 seconds. This replaces processing of missed blocks which was triggered in `onLogs` binding - and required waiting for next intent do be opened.

<!--- Describe your changes in detail -->

## Motivation and Context

Needed for missed intents to be processed ASAP after WebSocket reconnects. That prevents  them from hitting their `fillDeadline` and also improves UX.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

Tested on a local instance of `sealed-bid-auction` with `solverBot.ts` , against mainnet `v09` contracts.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes (remove all unchecked types)

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Style (style only changes)
-   [ ] Docs
-   [ ] Refactor (code that does not add new functionality nor fixes a bug)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

-   [x] If my change requires a change to the documentation, I have updated the documentation accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additions or updates to any deployment scripts to ensure that the protocol is functional (Makefile, Dockerfile, Forge Script, etc.), I have made these changes, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.
-   [x] If my change requires additional test coverage, I have created those tests accordingly, and in either case, have checked this box to attest to my assessment of this requirement with regard to my change.